### PR TITLE
feat(music-services): add YouTube and Amazon Music integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,11 @@ ENV/
 env.bak/
 venv.bak/
 
-# Environment variables
+# Environment variables and credentials
 .env
+spotify.env
+youtube_music.env
+amazon_music.env
 
 # IDE
 .vscode/
@@ -85,10 +88,18 @@ Desktop.ini
 
 # Application-specific
 playlist_history.json
+*_usage_history.json
+youtube_usage_history.json
 *.log
 .history/
 
 # Spotify API tokens (if any)
 *.token
 access_token.json
-refresh_token.json 
+refresh_token.json
+
+# OAuth credentials and tokens
+client_secret_*.json
+youtube_token.json
+*.token
+*_token.json 

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,0 +1,488 @@
+# 🛠️ Service Integration Guide
+
+This guide provides detailed steps for integrating YouTube Music and Amazon Music into the Multi-Service Music Playlist Generator.
+
+## 📋 **Prerequisites**
+
+Before starting any integration:
+1. ✅ **Working Spotify Integration** - Ensure the base system works
+2. ✅ **Python 3.8+** and all dependencies installed
+3. ✅ **Developer Account** for the target music service
+4. ✅ **API Access** and credentials for the service
+
+## 🎬 **YouTube Music Integration**
+
+### **Phase 1: Setup Developer Access**
+
+1. **Create Google Cloud Project**
+   ```bash
+   # Visit: https://console.developers.google.com/
+   # 1. Create new project or select existing
+   # 2. Enable YouTube Data API v3
+   # 3. Create OAuth 2.0 credentials
+   # 4. Download credentials.json
+   ```
+
+2. **Install YouTube Music Dependencies**
+   ```bash
+   pip3 install ytmusicapi google-auth google-auth-oauthlib google-auth-httplib2
+   ```
+
+3. **Update Requirements**
+   ```bash
+   # Add to requirements.txt:
+   echo "ytmusicapi==1.3.2" >> requirements.txt
+   echo "google-auth==2.17.3" >> requirements.txt
+   echo "google-auth-oauthlib==1.0.0" >> requirements.txt
+   echo "google-auth-httplib2==0.1.0" >> requirements.txt
+   ```
+
+### **Phase 2: Implement Service Classes**
+
+1. **Create YouTube Music Service**
+   ```python
+   # File: services/youtube_service.py
+   from typing import Dict, List, Any, Optional, Tuple
+   from ytmusicapi import YTMusic
+   from google.auth.transport.requests import Request
+   from google_auth_oauthlib.flow import Flow
+   
+   from base_music_service import BaseMusicService, MusicServiceType, TrackInfo, PlaylistInfo, ArtistInfo
+   
+   class YouTubeMusicService(BaseMusicService):
+       def __init__(self, config: Dict[str, Any]):
+           super().__init__(config)
+           self.ytmusic: Optional[YTMusic] = None
+       
+       @property
+       def service_type(self) -> MusicServiceType:
+           return MusicServiceType.YOUTUBE_MUSIC
+       
+       @property
+       def service_name(self) -> str:
+           return "YouTube Music"
+       
+       def validate_config(self) -> Tuple[bool, List[str]]:
+           errors = []
+           required_keys = [
+               'YOUTUBE_CLIENT_ID',
+               'YOUTUBE_CLIENT_SECRET', 
+               'YOUTUBE_REDIRECT_URI',
+               'REFERENCE_PLAYLIST_ID'
+           ]
+           
+           for key in required_keys:
+               if not self.config.get(key):
+                   errors.append(f"Missing required configuration: {key}")
+           
+           return len(errors) == 0, errors
+       
+       async def authenticate(self) -> bool:
+           try:
+               # YouTube Music OAuth flow
+               flow = Flow.from_client_config(
+                   {
+                       "web": {
+                           "client_id": self.config['YOUTUBE_CLIENT_ID'],
+                           "client_secret": self.config['YOUTUBE_CLIENT_SECRET'],
+                           "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                           "token_uri": "https://oauth2.googleapis.com/token",
+                           "redirect_uris": [self.config['YOUTUBE_REDIRECT_URI']]
+                       }
+                   },
+                   scopes=['https://www.googleapis.com/auth/youtube']
+               )
+               flow.redirect_uri = self.config['YOUTUBE_REDIRECT_URI']
+               
+               # Setup YTMusic with OAuth
+               self.ytmusic = YTMusic()  # Will need proper OAuth setup
+               self.authenticated = True
+               return True
+               
+           except Exception as e:
+               logger.error(f"YouTube Music authentication failed: {e}")
+               return False
+       
+       async def get_current_user(self) -> Dict[str, Any]:
+           # Implement user info retrieval
+           pass
+       
+       async def get_playlist_tracks(self, playlist_id: str) -> List[TrackInfo]:
+           if not self.authenticated or not self.ytmusic:
+               raise Exception("Not authenticated with YouTube Music")
+           
+           tracks = []
+           playlist = self.ytmusic.get_playlist(playlist_id)
+           
+           for track in playlist['tracks']:
+               track_info = TrackInfo(
+                   id=track['videoId'],
+                   name=track['title'],
+                   artist=', '.join([artist['name'] for artist in track['artists']]),
+                   album=track.get('album', {}).get('name', 'Unknown'),
+                   uri=f"https://music.youtube.com/watch?v={track['videoId']}",
+                   external_url=f"https://music.youtube.com/watch?v={track['videoId']}",
+                   duration_ms=track.get('duration_seconds', 0) * 1000,
+                   explicit=False,  # YouTube Music doesn't expose this easily
+                   popularity=None  # Not available
+               )
+               tracks.append(track_info)
+           
+           return tracks
+       
+       # Implement all other required methods...
+       async def create_playlist(self, name: str, description: str = "", public: bool = True) -> PlaylistInfo:
+           # Implementation here
+           pass
+       
+       async def search_tracks(self, query: str, limit: int = 20) -> List[TrackInfo]:
+           # Implementation here
+           pass
+       
+       # ... other methods
+   ```
+
+2. **Create YouTube Discovery Engine**
+   ```python
+   # File: services/youtube_discovery.py
+   from base_music_service import BaseDiscoveryEngine
+   from services.youtube_service import YouTubeMusicService
+   
+   class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
+       def __init__(self, music_service: YouTubeMusicService):
+           super().__init__(music_service)
+           self.youtube = music_service
+       
+       async def discover_new_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+           # Implement YouTube-specific discovery logic
+           try:
+               # 1. Analyze taste profile from reference playlist
+               taste_profile = await self.analyze_taste_profile(reference_playlist_id)
+               
+               # 2. Use YouTube Music search to find new tracks
+               discovered_tracks = await self._discover_tracks(taste_profile, target_size * 2)
+               
+               # 3. Filter and select best tracks
+               selected_tracks = self._select_best_tracks(discovered_tracks, target_size)
+               
+               # 4. Create playlist
+               result = await self._create_discovery_playlist(selected_tracks, taste_profile)
+               
+               return result
+               
+           except Exception as e:
+               logger.error(f"YouTube discovery failed: {e}")
+               raise
+       
+       async def analyze_taste_profile(self, reference_playlist_id: str) -> Dict[str, Any]:
+           # Implement taste analysis for YouTube Music
+           pass
+       
+       async def _discover_tracks(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+           # Use YouTube Music search APIs
+           pass
+   ```
+
+3. **Create YouTube Curator**
+   ```python
+   # File: services/youtube_curator.py
+   from base_music_service import BaseCurator
+   from services.youtube_service import YouTubeMusicService
+   
+   class YouTubeCurator(BaseCurator):
+       def __init__(self, music_service: YouTubeMusicService):
+           super().__init__(music_service)
+           self.youtube = music_service
+       
+       async def generate_curated_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+           # Implement YouTube-specific curation logic
+           pass
+       
+       async def get_usage_stats(self) -> Dict[str, Any]:
+           # Implement usage statistics
+           pass
+   ```
+
+### **Phase 3: Register YouTube Music Service**
+
+1. **Update Service Type Enum**
+   ```python
+   # In base_music_service.py - already done!
+   class MusicServiceType(Enum):
+       SPOTIFY = "spotify"
+       YOUTUBE_MUSIC = "youtube_music"  # ✅ Already added
+       AMAZON_MUSIC = "amazon_music"
+   ```
+
+2. **Register in Main CLI**
+   ```python
+   # In main.py CLIContext._register_services()
+   try:
+       from services.youtube_service import YouTubeMusicService
+       from services.youtube_discovery import YouTubeDiscoveryEngine
+       from services.youtube_curator import YouTubeCurator
+       
+       self.service_manager.register_service(
+           MusicServiceType.YOUTUBE_MUSIC,
+           YouTubeMusicService,
+           YouTubeDiscoveryEngine,
+           YouTubeCurator
+       )
+   except ImportError:
+       logger.info("YouTube Music service not yet implemented")  # Remove this line
+   ```
+
+3. **Update Service Manager Template**
+   ```python
+   # In service_manager.py create_service_config_template()
+   # Already implemented! The template is ready.
+   ```
+
+### **Phase 4: Test Integration**
+
+```bash
+# Test the integration
+python3 main.py status                      # Should show YouTube Music
+python3 main.py setup youtube_music         # Create config template
+# Edit ~/.multi_music_generator/youtube_music.env with your credentials
+python3 main.py test youtube_music          # Test connection
+python3 main.py discover --service youtube_music --size 5
+```
+
+## 🛒 **Amazon Music Integration**
+
+### **Phase 1: Setup Developer Access**
+
+1. **Create Amazon Developer Account**
+   ```bash
+   # Visit: https://developer.amazon.com/
+   # 1. Sign up for developer account
+   # 2. Create new app
+   # 3. Request Amazon Music API access (requires approval)
+   # 4. Get client credentials
+   ```
+
+2. **Install Amazon Music Dependencies**
+   ```bash
+   pip3 install boto3 requests-oauthlib
+   ```
+
+3. **Update Requirements**
+   ```bash
+   # Add to requirements.txt:
+   echo "boto3==1.34.0" >> requirements.txt
+   echo "requests-oauthlib==1.3.1" >> requirements.txt
+   ```
+
+### **Phase 2: Implement Amazon Music Service**
+
+1. **Create Amazon Music Service**
+   ```python
+   # File: services/amazon_service.py
+   import boto3
+   from typing import Dict, List, Any, Optional, Tuple
+   
+   from base_music_service import BaseMusicService, MusicServiceType, TrackInfo, PlaylistInfo, ArtistInfo
+   
+   class AmazonMusicService(BaseMusicService):
+       def __init__(self, config: Dict[str, Any]):
+           super().__init__(config)
+           self.client = None
+       
+       @property
+       def service_type(self) -> MusicServiceType:
+           return MusicServiceType.AMAZON_MUSIC
+       
+       @property
+       def service_name(self) -> str:
+           return "Amazon Music"
+       
+       def validate_config(self) -> Tuple[bool, List[str]]:
+           errors = []
+           required_keys = [
+               'AMAZON_CLIENT_ID',
+               'AMAZON_CLIENT_SECRET',
+               'AMAZON_REDIRECT_URI',
+               'REFERENCE_PLAYLIST_ID'
+           ]
+           
+           for key in required_keys:
+               if not self.config.get(key):
+                   errors.append(f"Missing required configuration: {key}")
+           
+           return len(errors) == 0, errors
+       
+       async def authenticate(self) -> bool:
+           try:
+               # Amazon Music OAuth implementation
+               # Note: Amazon Music API is restrictive and requires business approval
+               self.authenticated = True
+               return True
+           except Exception as e:
+               logger.error(f"Amazon Music authentication failed: {e}")
+               return False
+       
+       # Implement all required methods...
+   ```
+
+2. **Create Amazon Discovery & Curator**
+   ```python
+   # File: services/amazon_discovery.py
+   from base_music_service import BaseDiscoveryEngine
+   from services.amazon_service import AmazonMusicService
+   
+   class AmazonDiscoveryEngine(BaseDiscoveryEngine):
+       # Similar structure to YouTube implementation
+       pass
+   
+   # File: services/amazon_curator.py  
+   from base_music_service import BaseCurator
+   from services.amazon_service import AmazonMusicService
+   
+   class AmazonCurator(BaseCurator):
+       # Similar structure to YouTube implementation
+       pass
+   ```
+
+### **Phase 3: Register Amazon Music**
+
+```python
+# In main.py CLIContext._register_services()
+try:
+    from services.amazon_service import AmazonMusicService
+    from services.amazon_discovery import AmazonDiscoveryEngine
+    from services.amazon_curator import AmazonCurator
+    
+    self.service_manager.register_service(
+        MusicServiceType.AMAZON_MUSIC,
+        AmazonMusicService,
+        AmazonDiscoveryEngine,
+        AmazonCurator
+    )
+except ImportError:
+    logger.info("Amazon Music service not yet implemented")  # Remove this line
+```
+
+## 🧪 **Testing Your Integration**
+
+### **Step-by-Step Testing**
+
+1. **Test Service Registration**
+   ```bash
+   python3 main.py status
+   # Should show your new service with ❌ Configuration: Invalid
+   ```
+
+2. **Test Configuration Template**
+   ```bash
+   python3 main.py setup your_service
+   # Should create config template with instructions
+   ```
+
+3. **Test Configuration Validation**
+   ```bash
+   # After adding credentials to config file:
+   python3 main.py status
+   # Should show ✅ Configuration: Valid
+   ```
+
+4. **Test Authentication**
+   ```bash
+   python3 main.py test your_service
+   # Should successfully connect and show user info
+   ```
+
+5. **Test Core Features**
+   ```bash
+   python3 main.py discover --service your_service --size 3
+   python3 main.py curate --service your_service --size 5
+   ```
+
+## 🚨 **Common Integration Issues**
+
+### **API Access Issues**
+- **YouTube Music**: Requires OAuth setup, quota limitations
+- **Amazon Music**: Very restrictive, requires business approval
+- **Rate Limiting**: Implement proper throttling and retry logic
+
+### **Authentication Problems**
+```python
+# Common OAuth flow pattern:
+async def authenticate(self) -> bool:
+    try:
+        # 1. Setup OAuth flow
+        # 2. Handle redirect and token exchange
+        # 3. Store tokens securely
+        # 4. Test API access
+        return True
+    except Exception as e:
+        logger.error(f"Auth failed: {e}")
+        return False
+```
+
+### **Data Mapping Issues**
+```python
+# Ensure consistent data mapping:
+def _map_track_data(self, api_track) -> TrackInfo:
+    return TrackInfo(
+        id=self._safe_get(api_track, 'id'),
+        name=self._safe_get(api_track, 'title', 'Unknown'),
+        artist=self._extract_artists(api_track),
+        album=self._safe_get(api_track, 'album', 'Unknown'),
+        # ... map all fields safely
+    )
+```
+
+## 📝 **Implementation Checklist**
+
+### **For Each New Service:**
+
+#### **✅ Phase 1: Setup**
+- [ ] Create developer account
+- [ ] Get API credentials
+- [ ] Install dependencies
+- [ ] Update requirements.txt
+
+#### **✅ Phase 2: Core Implementation**
+- [ ] Create `services/SERVICE_service.py`
+- [ ] Implement `BaseMusicService` interface
+- [ ] Add authentication logic
+- [ ] Implement all required methods
+
+#### **✅ Phase 3: Discovery & Curation**
+- [ ] Create `services/SERVICE_discovery.py`
+- [ ] Implement `BaseDiscoveryEngine` interface
+- [ ] Create `services/SERVICE_curator.py`
+- [ ] Implement `BaseCurator` interface
+
+#### **✅ Phase 4: Integration**
+- [ ] Register service in `main.py`
+- [ ] Update service manager templates
+- [ ] Add configuration validation
+- [ ] Test all CLI commands
+
+#### **✅ Phase 5: Testing**
+- [ ] Test service registration
+- [ ] Test configuration setup
+- [ ] Test authentication
+- [ ] Test discovery functionality
+- [ ] Test curation functionality
+
+## 💡 **Pro Tips**
+
+1. **Start Simple**: Implement basic playlist operations first
+2. **Copy Pattern**: Use Spotify implementation as a template
+3. **Error Handling**: Add comprehensive error messages
+4. **Rate Limiting**: Respect API quotas and add delays
+5. **Caching**: Cache API responses when possible
+6. **Testing**: Test with small playlists first
+
+## 🎯 **API Documentation References**
+
+- **YouTube Music**: [ytmusicapi docs](https://ytmusicapi.readthedocs.io/)
+- **Amazon Music**: [Amazon Music API](https://developer.amazon.com/docs/amazon-music/)
+- **Spotify**: [Spotify Web API](https://developer.spotify.com/documentation/web-api/) (reference)
+
+---
+
+**🚀 Ready to extend your music generator? Follow this guide step-by-step and you'll have multi-service support in no time!** 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,41 @@
-# Spotify Workout Playlist Generator
+# 🎵 Multi-Service Music Playlist Generator
 
-A smart music discovery and playlist curation tool that creates personalized workout playlists using Spotify's API. This tool bypasses Spotify's restricted Recommendations API (which requires business approval) by using creative discovery methods that work with standard developer accounts.
+A powerful, modular music discovery and playlist curation tool that works across multiple music streaming services. Discover new music and create smart playlists with advanced algorithms that bypass API restrictions and work with standard developer accounts.
 
-## 🎯 Features
+## 🌟 **Currently Supported Services**
+- ✅ **Spotify** - Fully implemented with Discovery & Curation
+- 🔧 **YouTube Music** - Ready for implementation
+- 🔧 **Amazon Music** - Ready for implementation
+
+## 🎯 **Key Features**
 
 ### 🔍 **Music Discovery Engine**
-- **Discovers completely NEW tracks** you've never heard
+- **Discovers completely NEW tracks** you've never heard before
 - **Analyzes your taste profile** from your reference playlist
-- **Genre-based discovery** using your favorite genres
-- **Related artist exploration** to find similar artists
+- **Multi-method discovery**: Genre search, related artists, workout-specific tracks
 - **Smart filtering** to exclude tracks you already know
-- **Perfect for expanding your music library**
+- **Bypasses API restrictions** using creative discovery methods
 
-### 🎵 **Enhanced Curator** 
-- **Smart playlist curation** from your existing favorites
+### 🎵 **Smart Curator**
 - **Anti-repetition algorithm** with usage history tracking
 - **Artist variety enforcement** to avoid repetitive playlists
-- **Freshness scoring** to show how varied each playlist is
-- **Perfect for creating fresh mixes from known favorites**
+- **Freshness scoring** to maximize playlist variety
+- **Usage statistics** to track curation performance
 
-## 🚀 Quick Start
+### 🏗️ **Modular Architecture**
+- **Service abstraction** for easy addition of new music platforms
+- **Centralized configuration** with per-service settings
+- **Interactive CLI** with guided setup and error handling
+- **Health monitoring** and service validation
 
-### Prerequisites
-- **Spotify Premium account**
+## 🚀 **Quick Start**
+
+### **Prerequisites**
 - **Python 3.8+**
-- **Spotify Developer App** (free to create)
+- **Music service account** (Spotify Premium recommended)
+- **Developer API credentials** for your chosen service
 
-### 1. Setup Spotify Developer App
-1. Go to [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/)
-2. Create a new app
-3. Add redirect URI: `http://127.0.0.1:8080/callback`
-4. Note your **Client ID** and **Client Secret**
-
-### 2. Installation
+### **1. Installation**
 ```bash
 # Clone the repository
 git clone <your-repo-url>
@@ -40,158 +43,371 @@ cd Spotify_workout_playlist
 
 # Install dependencies
 pip3 install -r requirements.txt
-
-# Setup environment variables
-cp .env.example .env
-# Edit .env with your Spotify credentials
 ```
 
-### 3. Configuration
-Edit `.env` with your credentials:
-```env
-SPOTIFY_CLIENT_ID=your_client_id_here
-SPOTIFY_CLIENT_SECRET=your_client_secret_here
-SPOTIFY_REDIRECT_URI=http://127.0.0.1:8080/callback
-REFERENCE_PLAYLIST_ID=your_reference_playlist_id
-```
-
-**Getting your Reference Playlist ID:**
-1. Open your workout playlist in Spotify
-2. Click "Share" → "Copy Spotify URI"
-3. Extract the ID from: `spotify:playlist:2dAT0EBXEe8KQt9FIyOsRP`
-4. Use: `2dAT0EBXEe8KQt9FIyOsRP`
-
-## 💡 Usage
-
-### 🔍 Discover New Music
-Find completely new tracks based on your taste:
+### **2. Check System Status**
 ```bash
-python3 music_discovery_engine.py
+python3 main.py status
 ```
 
-**What it does:**
-- Analyzes your reference playlist to understand your taste
-- Searches for new tracks in your favorite genres (metalcore, post-grunge, hard rock, etc.)
-- Finds tracks from artists related to your favorites
-- Creates a "Music Discovery" playlist with 30 new tracks
-- Filters out anything you already know
-
-**Example output:**
-```
-🎉 New music discovered successfully!
-📝 Discovery Playlist: Music Discovery - 2025-07-25
-🎵 New Tracks: 30
-🔗 Spotify URL: https://open.spotify.com/playlist/...
-
-🎯 Your Taste Profile:
-🎸 Favorite Genres: post-grunge, metalcore, hard rock, alternative metal
-👥 Artists Analyzed: 77
-
-🎵 Your new discoveries:
-  1. Walk - Pantera (search:heavy metal)
-  2. Second Chance - Shinedown (genre:post-grunge)
-  3. Don't Look Down - The Treatment (genre:hard rock)
-  ...
-```
-
-### 🎵 Create Smart Curated Playlists
-Generate variety from your existing favorites:
+### **3. Setup Your First Service (Spotify)**
 ```bash
-python3 enhanced_curator.py generate
+# Create configuration template
+python3 main.py setup spotify
+
+# Follow the setup instructions, then test
+python3 main.py test spotify
 ```
 
-**What it does:**
-- Selects 30 tracks from your 72-track reference playlist
-- Uses anti-repetition algorithm to avoid recently used tracks
-- Ensures artist variety and freshness
-- Tracks usage history to maximize variety over time
-- Creates both daily and main workout playlists
-
-**Example output:**
-```
-🎉 Enhanced workout playlist generated successfully!
-📝 Playlist: Daily Workout Mix - 2025-07-25
-🎵 Tracks: 30
-
-📊 Freshness Score: 70.0%
-🆕 Never used: 0 tracks
-🔄 Rarely used: 30 tracks
-♻️  Frequently used: 0 tracks
-```
-
-### 📊 Check Usage Statistics
-See how the curator is managing variety:
+### **4. Start Using!**
 ```bash
-python3 enhanced_curator.py stats
+# Discover new music
+python3 main.py discover --service spotify --size 10
+
+# Create curated playlists
+python3 main.py curate --service spotify --size 15
 ```
 
-## 🔧 Configuration Options
+## 📋 **Complete Command Reference**
 
-Edit `config.py` or `.env` to customize:
-
-```env
-# Playlist settings
-TARGET_PLAYLIST_NAME="Daily Workout Mix"
-PLAYLIST_SIZE=30
-
-# Discovery settings  
-DAILY_GENERATION_TIME="08:00"
-CLEANUP_OLDER_THAN_DAYS=30
+### **System Management**
+```bash
+python3 main.py status              # Show all services status
+python3 main.py setup <service>     # Setup specific service
+python3 main.py test <service>      # Test service connection  
+python3 main.py health              # Health check all services
 ```
 
-## 📁 Project Structure
+### **Music Generation**
+```bash
+# Interactive mode (auto-selects available service)
+python3 main.py discover            # Find new music
+python3 main.py curate             # Create smart playlist
+
+# Explicit service selection
+python3 main.py discover --service spotify --size 20
+python3 main.py curate --service youtube_music --size 25
+python3 main.py discover --reference-playlist PLAYLIST_ID
+```
+
+### **Get Help**
+```bash
+python3 main.py --help             # Main help
+python3 main.py discover --help    # Command-specific help
+```
+
+## ⚙️ **Service Setup Guides**
+
+### **🎵 Spotify Setup**
+
+1. **Create Spotify Developer App**
+   - Go to [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/)
+   - Create a new app
+   - Add redirect URI: `http://127.0.0.1:8080/callback`
+   - Note your **Client ID** and **Client Secret**
+
+2. **Configure the Service**
+   ```bash
+   python3 main.py setup spotify
+   # Edit: ~/.multi_music_generator/spotify.env
+   ```
+
+3. **Required Configuration**
+   ```env
+   SPOTIFY_CLIENT_ID=your_client_id_here
+   SPOTIFY_CLIENT_SECRET=your_client_secret_here
+   SPOTIFY_REDIRECT_URI=http://127.0.0.1:8080/callback
+   REFERENCE_PLAYLIST_ID=your_playlist_id_here
+   ```
+
+4. **Get Reference Playlist ID**
+   - Open your workout playlist in Spotify
+   - Click "Share" → "Copy Spotify URI"
+   - Extract ID from: `spotify:playlist:2dAT0EBXEe8KQt9FIyOsRP`
+   - Use: `2dAT0EBXEe8KQt9FIyOsRP`
+
+### **🎬 YouTube Music Setup** (Coming Soon)
+
+1. **Create Google Developer Project**
+   - Go to [Google Cloud Console](https://console.developers.google.com/)
+   - Create new project or select existing
+   - Enable YouTube Data API v3
+   - Create OAuth 2.0 credentials
+
+2. **Configure the Service**
+   ```bash
+   python3 main.py setup youtube_music
+   # Edit: ~/.multi_music_generator/youtube_music.env
+   ```
+
+3. **Required Configuration**
+   ```env
+   YOUTUBE_CLIENT_ID=your_client_id_here
+   YOUTUBE_CLIENT_SECRET=your_client_secret_here
+   YOUTUBE_REDIRECT_URI=http://localhost:8080/callback
+   REFERENCE_PLAYLIST_ID=your_playlist_id_here
+   ```
+
+### **🛒 Amazon Music Setup** (Coming Soon)
+
+1. **Create Amazon Developer Account**
+   - Go to [Amazon Developer Portal](https://developer.amazon.com/)
+   - Create new app in your developer account
+   - Request Music API access (requires approval)
+
+2. **Configure the Service**
+   ```bash
+   python3 main.py setup amazon_music
+   # Edit: ~/.multi_music_generator/amazon_music.env
+   ```
+
+## 🛠️ **Adding New Music Services**
+
+### **Step-by-Step Integration Guide**
+
+**1. Create Service Implementation**
+```bash
+# Create service files in the services/ directory
+touch services/SERVICE_service.py
+touch services/SERVICE_discovery.py
+touch services/SERVICE_curator.py
+```
+
+**2. Implement Base Classes**
+```python
+# services/SERVICE_service.py
+from base_music_service import BaseMusicService, MusicServiceType, TrackInfo, PlaylistInfo, ArtistInfo
+
+class YourMusicService(BaseMusicService):
+    @property
+    def service_type(self) -> MusicServiceType:
+        return MusicServiceType.YOUR_SERVICE
+    
+    @property  
+    def service_name(self) -> str:
+        return "Your Service Name"
+    
+    # Implement all abstract methods...
+    async def authenticate(self) -> bool:
+        # Your authentication logic
+        pass
+    
+    async def get_playlist_tracks(self, playlist_id: str) -> List[TrackInfo]:
+        # Your playlist fetching logic
+        pass
+    
+    # ... implement all other required methods
+```
+
+**3. Implement Discovery Engine**
+```python
+# services/SERVICE_discovery.py
+from base_music_service import BaseDiscoveryEngine
+
+class YourDiscoveryEngine(BaseDiscoveryEngine):
+    async def discover_new_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        # Your discovery logic
+        pass
+    
+    async def analyze_taste_profile(self, reference_playlist_id: str) -> Dict[str, Any]:
+        # Your taste analysis logic
+        pass
+```
+
+**4. Implement Curator**
+```python
+# services/SERVICE_curator.py
+from base_music_service import BaseCurator
+
+class YourCurator(BaseCurator):
+    async def generate_curated_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        # Your curation logic
+        pass
+    
+    async def get_usage_stats(self) -> Dict[str, Any]:
+        # Your statistics logic
+        pass
+```
+
+**5. Register the Service**
+```python
+# Add to main.py in CLIContext._register_services()
+try:
+    from services.your_service import YourMusicService
+    from services.your_discovery import YourDiscoveryEngine  
+    from services.your_curator import YourCurator
+    
+    self.service_manager.register_service(
+        MusicServiceType.YOUR_SERVICE,
+        YourMusicService,
+        YourDiscoveryEngine,
+        YourCurator
+    )
+except ImportError:
+    logger.info("Your service not yet implemented")
+```
+
+**6. Add Service Type**
+```python
+# Add to base_music_service.py in MusicServiceType enum
+class MusicServiceType(Enum):
+    SPOTIFY = "spotify"
+    YOUTUBE_MUSIC = "youtube_music"
+    AMAZON_MUSIC = "amazon_music"
+    YOUR_SERVICE = "your_service"  # Add this line
+```
+
+**7. Update Service Manager Templates**
+```python
+# Add configuration template in service_manager.py
+elif service_type == MusicServiceType.YOUR_SERVICE:
+    template = """# Your Service Configuration
+# Your setup instructions here
+
+YOUR_CLIENT_ID=your_client_id_here
+YOUR_CLIENT_SECRET=your_client_secret_here
+# ... other config options
+"""
+```
+
+**8. Test Your Integration**
+```bash
+python3 main.py status              # Should show your service
+python3 main.py setup your_service  # Should create config template
+python3 main.py test your_service   # Should test connection
+```
+
+## 📁 **Project Structure**
 
 ```
 Spotify_workout_playlist/
-├── music_discovery_engine.py    # 🔍 NEW music discovery
-├── enhanced_curator.py          # 🎵 Smart curation with history
-├── spotify_client.py            # 🎧 Spotify API integration
-├── config.py                    # ⚙️  Configuration management
-├── requirements.txt             # 📦 Python dependencies
-├── .env.example                 # 📝 Environment template
-└── README.md                    # 📚 Documentation
+├── main.py                          # 🚀 Main CLI interface
+├── base_music_service.py            # 🏗️  Abstract base classes
+├── service_manager.py               # 🔧 Service management & validation
+├── services/                        # 📂 Service implementations
+│   ├── __init__.py
+│   ├── spotify_service.py           # 🎵 Spotify API integration
+│   ├── spotify_discovery.py         # 🔍 Spotify discovery engine
+│   ├── spotify_curator.py           # 🎵 Spotify curation engine
+│   ├── youtube_service.py           # 🎬 YouTube Music (template ready)
+│   └── amazon_service.py            # 🛒 Amazon Music (template ready)
+├── requirements.txt                 # 📦 Python dependencies
+├── .env.example                     # 📝 Environment template (legacy)
+└── README.md                        # 📚 This documentation
 ```
 
-## 🤔 Why This Approach Works Better
+## 💡 **Usage Examples**
 
-### ❌ Spotify's Limitations
-- **Recommendations API**: Requires business approval (250k+ users)
-- **Audio Features API**: Limited for development apps
-- **Extended Quota**: Only for established companies
+### **🔍 Music Discovery**
+```bash
+# Discover 20 new tracks
+python3 main.py discover --service spotify --size 20
 
-### ✅ Our Solution Benefits
-- **🎯 Better Quality Control**: Every discovery is in your favorite genres
-- **🔄 Infinite Variety**: Genre-based discovery never runs out
-- **⚡ Zero Dependencies**: No approval needed, works immediately
-- **🎵 Taste-Focused**: Based on YOUR actual preferences
+# Use specific reference playlist  
+python3 main.py discover --reference-playlist 2dAT0EBXEe8KQt9FIyOsRP --size 15
 
-## 🛠️ Troubleshooting
+# Interactive mode (auto-selects service)
+python3 main.py discover
+```
 
-### Authentication Issues
-- Ensure redirect URI matches exactly: `http://127.0.0.1:8080/callback`
-- Check Client ID and Secret are correct
-- Try different redirect URI options in `.env.example`
+**Example Output:**
+```
+🎉 Discovery completed!
+📝 New Playlist: Music Discovery - 2025-07-28
+🎵 Tracks Discovered: 20
+🔗 Listen: https://open.spotify.com/playlist/...
 
-### No New Tracks Found
-- Expand your reference playlist (add more varied artists)
-- Check if your genres are too niche
-- Try running discovery multiple times
+🎯 Your Taste Profile:
+🎸 Genres: alternative metal, post-grunge, metalcore, rap metal, nu metal
+👥 Artists Analyzed: 50
+```
 
-### Rate Limiting
-- The tool respects Spotify's rate limits
-- If you hit limits, wait a few minutes and retry
+### **🎵 Smart Curation**
+```bash
+# Create curated playlist
+python3 main.py curate --service spotify --size 25
 
-## 🎵 Perfect For
+# Interactive mode
+python3 main.py curate
+```
 
-- **🏋️ Workout Enthusiasts**: High-energy track discovery
-- **🎸 Rock/Metal Fans**: Excellent genre coverage for heavy music
-- **🔍 Music Discoverers**: Finding hidden gems in your favorite styles
-- **📱 Playlist Curators**: Creating fresh mixes without repetition
+**Example Output:**
+```
+🎉 Curation completed!
+📝 Playlist: Daily Workout Mix - 2025-07-28
+🎵 Tracks: 25
+🔗 Listen: https://open.spotify.com/playlist/...
+📊 Freshness Score: 75.5%
+```
 
-## 📄 License
+## 🔧 **Configuration**
 
-This project is for personal use. Ensure compliance with Spotify's Developer Terms of Service.
+### **Per-Service Configuration**
+Each service gets its own configuration file:
+- **Spotify**: `~/.multi_music_generator/spotify.env`
+- **YouTube Music**: `~/.multi_music_generator/youtube_music.env`
+- **Amazon Music**: `~/.multi_music_generator/amazon_music.env`
+
+### **Common Options**
+```env
+# Playlist settings
+TARGET_PLAYLIST_NAME=Daily Workout Mix
+PLAYLIST_SIZE=30
+
+# Optional customization
+UPDATE_TIME=07:00
+TARGET_ENERGY=0.8
+TARGET_DANCEABILITY=0.7
+```
+
+## 🛠️ **Troubleshooting**
+
+### **Service Issues**
+```bash
+python3 main.py status    # Check service configuration
+python3 main.py health    # Test service connections
+```
+
+### **Common Problems**
+- **Authentication errors**: Check API credentials and redirect URIs
+- **No tracks found**: Expand reference playlist or try different genres
+- **Rate limiting**: Wait a few minutes and retry
+- **Service not found**: Ensure service module is properly imported
+
+### **Getting Help**
+- Use `--help` with any command for detailed options
+- Check service-specific error messages for troubleshooting steps
+- Review configuration files for missing or incorrect values
+
+## 🎯 **Why This Approach Works**
+
+### **✅ Advantages**
+- **🔓 No API Restrictions**: Bypasses recommendation API limitations
+- **🎯 Better Control**: Discover exactly the genres you want
+- **🔄 Infinite Variety**: Never runs out of new music to find
+- **⚡ Works Immediately**: No business approval or extended quotas needed
+- **🏗️ Modular Design**: Easy to add new music services
+- **💡 User-Friendly**: Clear error messages and setup guidance
+
+### **🎵 Perfect For**
+- **🏋️ Workout enthusiasts** looking for high-energy tracks
+- **🎸 Genre-specific listeners** (rock, metal, electronic, etc.)
+- **🔍 Music discoverers** wanting to expand their library
+- **📱 Playlist curators** needing variety without repetition
+- **🛠️ Developers** wanting to add music service integrations
+
+## 📄 **License**
+
+This project is for personal use. Ensure compliance with each music service's Developer Terms of Service.
 
 ---
 
-**🎵 Start discovering your next favorite workout tracks!** 💪 
+**🎵 Start discovering your next favorite tracks across multiple music services!** 🚀
+
+### **Quick Commands to Get Started:**
+```bash
+python3 main.py setup spotify      # Setup Spotify
+python3 main.py test spotify       # Test connection  
+python3 main.py discover --size 10 # Find 10 new tracks
+python3 main.py curate --size 15   # Create smart playlist
+``` 

--- a/base_music_service.py
+++ b/base_music_service.py
@@ -1,0 +1,303 @@
+"""Abstract base classes for music service integrations."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Any, Optional, Tuple
+from dataclasses import dataclass
+from enum import Enum
+
+
+class MusicServiceType(Enum):
+    """Supported music service types."""
+    SPOTIFY = "spotify"
+    YOUTUBE_MUSIC = "youtube_music"
+    AMAZON_MUSIC = "amazon_music"
+
+
+@dataclass
+class TrackInfo:
+    """Standardized track information across all services."""
+    id: str
+    name: str
+    artist: str
+    album: str
+    uri: str  # Service-specific URI
+    external_url: str
+    duration_ms: int
+    explicit: bool = False
+    popularity: Optional[int] = None
+    genres: List[str] = None
+    
+    def __post_init__(self):
+        if self.genres is None:
+            self.genres = []
+
+
+@dataclass
+class PlaylistInfo:
+    """Standardized playlist information across all services."""
+    id: str
+    name: str
+    description: str
+    track_count: int
+    external_url: str
+    public: bool = True
+
+
+@dataclass
+class ArtistInfo:
+    """Standardized artist information across all services."""
+    id: str
+    name: str
+    genres: List[str]
+    popularity: Optional[int] = None
+    external_url: str = ""
+    
+    def __post_init__(self):
+        if self.genres is None:
+            self.genres = []
+
+
+class BaseMusicService(ABC):
+    """Abstract base class for music service integrations."""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize the music service with configuration."""
+        self.config = config
+        self.authenticated = False
+    
+    @abstractmethod
+    async def authenticate(self) -> bool:
+        """Authenticate with the music service.
+        
+        Returns:
+            bool: True if authentication successful, False otherwise
+        """
+        pass
+    
+    @abstractmethod
+    async def get_current_user(self) -> Dict[str, Any]:
+        """Get current authenticated user information."""
+        pass
+    
+    @abstractmethod
+    async def get_playlist_tracks(self, playlist_id: str) -> List[TrackInfo]:
+        """Get all tracks from a playlist.
+        
+        Args:
+            playlist_id: The playlist identifier
+            
+        Returns:
+            List of TrackInfo objects
+        """
+        pass
+    
+    @abstractmethod
+    async def create_playlist(self, name: str, description: str = "", public: bool = True) -> PlaylistInfo:
+        """Create a new playlist.
+        
+        Args:
+            name: Playlist name
+            description: Playlist description
+            public: Whether the playlist should be public
+            
+        Returns:
+            PlaylistInfo object with created playlist details
+        """
+        pass
+    
+    @abstractmethod
+    async def update_playlist_tracks(self, playlist_id: str, track_uris: List[str]) -> bool:
+        """Update playlist with new tracks (replaces existing tracks).
+        
+        Args:
+            playlist_id: The playlist identifier
+            track_uris: List of track URIs to set as playlist content
+            
+        Returns:
+            bool: True if successful
+        """
+        pass
+    
+    @abstractmethod
+    async def find_playlist_by_name(self, name: str) -> Optional[PlaylistInfo]:
+        """Find a playlist by name in user's library.
+        
+        Args:
+            name: Playlist name to search for
+            
+        Returns:
+            PlaylistInfo if found, None otherwise
+        """
+        pass
+    
+    @abstractmethod
+    async def search_tracks(self, query: str, limit: int = 20) -> List[TrackInfo]:
+        """Search for tracks using a query string.
+        
+        Args:
+            query: Search query (genre, artist, etc.)
+            limit: Maximum number of results
+            
+        Returns:
+            List of TrackInfo objects
+        """
+        pass
+    
+    @abstractmethod
+    async def get_artist_info(self, artist_id: str) -> ArtistInfo:
+        """Get detailed artist information.
+        
+        Args:
+            artist_id: The artist identifier
+            
+        Returns:
+            ArtistInfo object
+        """
+        pass
+    
+    @abstractmethod
+    async def get_related_artists(self, artist_id: str) -> List[ArtistInfo]:
+        """Get artists related to the given artist.
+        
+        Args:
+            artist_id: The artist identifier
+            
+        Returns:
+            List of related ArtistInfo objects
+        """
+        pass
+    
+    @abstractmethod
+    async def get_artist_top_tracks(self, artist_id: str, limit: int = 10) -> List[TrackInfo]:
+        """Get top tracks for an artist.
+        
+        Args:
+            artist_id: The artist identifier
+            limit: Maximum number of tracks
+            
+        Returns:
+            List of TrackInfo objects
+        """
+        pass
+    
+    @abstractmethod
+    async def get_user_saved_tracks(self, limit: int = 50) -> List[TrackInfo]:
+        """Get user's saved/liked tracks.
+        
+        Args:
+            limit: Maximum number of tracks to fetch
+            
+        Returns:
+            List of TrackInfo objects
+        """
+        pass
+    
+    @property
+    @abstractmethod
+    def service_type(self) -> MusicServiceType:
+        """Get the service type."""
+        pass
+    
+    @property
+    @abstractmethod
+    def service_name(self) -> str:
+        """Get the human-readable service name."""
+        pass
+    
+    def validate_config(self) -> Tuple[bool, List[str]]:
+        """Validate the service configuration.
+        
+        Returns:
+            Tuple of (is_valid, list_of_error_messages)
+        """
+        errors = []
+        
+        # Common validation - subclasses should override this
+        if not self.config:
+            errors.append("Configuration is empty")
+            
+        return len(errors) == 0, errors
+    
+    async def health_check(self) -> Tuple[bool, str]:
+        """Perform a health check on the service.
+        
+        Returns:
+            Tuple of (is_healthy, status_message)
+        """
+        try:
+            if not self.authenticated:
+                auth_success = await self.authenticate()
+                if not auth_success:
+                    return False, "Authentication failed"
+            
+            user = await self.get_current_user()
+            if user:
+                return True, f"Connected as {user.get('name', 'Unknown User')}"
+            else:
+                return False, "Failed to get user information"
+                
+        except Exception as e:
+            return False, f"Health check failed: {str(e)}"
+
+
+class BaseDiscoveryEngine(ABC):
+    """Abstract base class for music discovery engines."""
+    
+    def __init__(self, music_service: BaseMusicService):
+        """Initialize with a music service."""
+        self.music_service = music_service
+    
+    @abstractmethod
+    async def discover_new_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Discover new tracks based on a reference playlist.
+        
+        Args:
+            reference_playlist_id: ID of the reference playlist
+            target_size: Number of tracks to discover
+            
+        Returns:
+            Dict containing discovered tracks and metadata
+        """
+        pass
+    
+    @abstractmethod
+    async def analyze_taste_profile(self, reference_playlist_id: str) -> Dict[str, Any]:
+        """Analyze user's taste profile from reference playlist.
+        
+        Args:
+            reference_playlist_id: ID of the reference playlist
+            
+        Returns:
+            Dict containing taste profile (genres, artists, etc.)
+        """
+        pass
+
+
+class BaseCurator(ABC):
+    """Abstract base class for playlist curators."""
+    
+    def __init__(self, music_service: BaseMusicService):
+        """Initialize with a music service."""
+        self.music_service = music_service
+    
+    @abstractmethod
+    async def generate_curated_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Generate a curated playlist from existing tracks.
+        
+        Args:
+            reference_playlist_id: ID of the reference playlist
+            target_size: Number of tracks for the new playlist
+            
+        Returns:
+            Dict containing curated playlist info and stats
+        """
+        pass
+    
+    @abstractmethod
+    async def get_usage_stats(self) -> Dict[str, Any]:
+        """Get usage statistics for the curator.
+        
+        Returns:
+            Dict containing usage statistics
+        """
+        pass 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,467 @@
+"""Multi-Service Music Playlist Generator - Main CLI Interface."""
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from loguru import logger
+
+from base_music_service import MusicServiceType
+from service_manager import ServiceManager, MusicServiceError
+
+
+# Configure logger
+logger.remove()
+logger.add(sys.stderr, level="INFO", format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>")
+
+
+class CLIContext:
+    """Context object for CLI commands."""
+    
+    def __init__(self):
+        self.service_manager = ServiceManager()
+        self._register_services()
+    
+    def _register_services(self):
+        """Register all available services."""
+        # Import and register services as they become available
+        try:
+            from services.spotify_service import SpotifyService
+            from services.spotify_discovery import SpotifyDiscoveryEngine
+            from services.spotify_curator import SpotifyCurator
+            
+            self.service_manager.register_service(
+                MusicServiceType.SPOTIFY,
+                SpotifyService,
+                SpotifyDiscoveryEngine,
+                SpotifyCurator
+            )
+        except ImportError:
+            logger.warning("Spotify service not available")
+        
+        try:
+            from services.youtube_service import YouTubeMusicService
+            from services.youtube_discovery import YouTubeDiscoveryEngine
+            from services.youtube_curator import YouTubeCurator
+            
+            self.service_manager.register_service(
+                MusicServiceType.YOUTUBE_MUSIC,
+                YouTubeMusicService,
+                YouTubeDiscoveryEngine,
+                YouTubeCurator
+            )
+        except ImportError:
+            logger.warning("YouTube Music service not available")
+        
+        try:
+            from services.amazon_service import AmazonMusicService
+            from services.amazon_discovery import AmazonDiscoveryEngine
+            from services.amazon_curator import AmazonCurator
+            
+            self.service_manager.register_service(
+                MusicServiceType.AMAZON_MUSIC,
+                AmazonMusicService,
+                AmazonDiscoveryEngine,
+                AmazonCurator
+            )
+        except ImportError:
+            logger.info("Amazon Music service not yet implemented")
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    """🎵 Multi-Service Music Playlist Generator
+    
+    Discover new music and create smart playlists across multiple music services.
+    
+    Supported services: Spotify, YouTube Music, Amazon Music
+    """
+    ctx.ensure_object(CLIContext)
+
+
+@cli.command()
+@click.pass_obj
+def status(ctx: CLIContext):
+    """📊 Show status of all music services."""
+    click.echo("🎵 Multi-Service Music Generator Status\n")
+    
+    available_services = ctx.service_manager.get_available_services()
+    if not available_services:
+        click.echo("❌ No music services are available!")
+        click.echo("💡 Make sure service modules are properly installed.")
+        return
+    
+    status_info = ctx.service_manager.get_service_status()
+    
+    for service_name, info in status_info.items():
+        service_display = service_name.replace('_', ' ').title()
+        
+        # Service header
+        if info['configured']:
+            click.echo(f"✅ {service_display}")
+        else:
+            click.echo(f"❌ {service_display}")
+        
+        # Configuration status
+        click.echo(f"   📁 Config: {info['config_file']}")
+        
+        if info['configured']:
+            click.echo(f"   ✅ Configuration: Valid")
+        else:
+            click.echo(f"   ❌ Configuration: Invalid")
+            for error in info['errors']:
+                click.echo(f"      • {error}")
+        
+        # Available features
+        features = []
+        if info['has_discovery']:
+            features.append("🔍 Discovery")
+        if info['has_curator']:
+            features.append("🎵 Curation")
+        
+        if features:
+            click.echo(f"   🎯 Features: {', '.join(features)}")
+        else:
+            click.echo(f"   ⚠️  Features: None available")
+        
+        click.echo()
+    
+    # Show setup suggestions
+    unconfigured = [name for name, info in status_info.items() if not info['configured']]
+    if unconfigured:
+        click.echo("💡 To get started:")
+        for service in unconfigured:
+            click.echo(f"   python main.py setup {service}")
+
+
+@cli.command()
+@click.argument('service', type=click.Choice(['spotify', 'youtube_music', 'amazon_music']))
+@click.pass_obj
+def setup(ctx: CLIContext, service: str):
+    """⚙️ Setup configuration for a music service."""
+    try:
+        service_type = MusicServiceType(service)
+    except ValueError:
+        click.echo(f"❌ Unknown service: {service}")
+        return
+    
+    click.echo(f"🎵 Setting up {service.replace('_', ' ').title()}")
+    click.echo()
+    
+    # Create config template
+    try:
+        config_file = ctx.service_manager.create_service_config_template(service_type)
+        click.echo(f"📁 Created configuration template: {config_file}")
+        click.echo()
+        
+        # Show service-specific setup instructions
+        if service_type == MusicServiceType.SPOTIFY:
+            click.echo("🎯 Spotify Setup Instructions:")
+            click.echo("1. Go to: https://developer.spotify.com/dashboard/")
+            click.echo("2. Create a new app")
+            click.echo("3. Add redirect URI: http://127.0.0.1:8080/callback")
+            click.echo("4. Copy your Client ID and Client Secret")
+            click.echo()
+            click.echo("📋 Get your reference playlist ID:")
+            click.echo("1. Open your workout playlist in Spotify")
+            click.echo("2. Click Share → Copy Spotify URI")
+            click.echo("3. Extract ID from: spotify:playlist:YOUR_PLAYLIST_ID")
+        
+        elif service_type == MusicServiceType.YOUTUBE_MUSIC:
+            click.echo("🎯 YouTube Music Setup Instructions:")
+            click.echo("1. Go to: https://console.developers.google.com/")
+            click.echo("2. Create a new project or select existing")
+            click.echo("3. Enable YouTube Data API v3")
+            click.echo("4. Create OAuth 2.0 credentials")
+            click.echo("5. Add redirect URI: http://localhost:8080/callback")
+            click.echo()
+            click.echo("⚠️  Note: YouTube Music API access may require approval")
+        
+        elif service_type == MusicServiceType.AMAZON_MUSIC:
+            click.echo("🎯 Amazon Music Setup Instructions:")
+            click.echo("1. Go to: https://developer.amazon.com/")
+            click.echo("2. Create a new app in your developer account")
+            click.echo("3. Request Music API access (requires approval)")
+            click.echo("4. Configure OAuth settings")
+            click.echo()
+            click.echo("⚠️  Note: Amazon Music API requires business approval")
+        
+        click.echo()
+        click.echo(f"✏️  Edit the configuration file: {config_file}")
+        click.echo(f"🧪 Test your setup: python main.py test {service}")
+        
+    except Exception as e:
+        click.echo(f"❌ Failed to create setup: {e}")
+
+
+@cli.command()
+@click.argument('service', type=click.Choice(['spotify', 'youtube_music', 'amazon_music']))
+@click.pass_obj
+def test(ctx: CLIContext, service: str):
+    """🧪 Test connection to a music service."""
+    async def test_service():
+        try:
+            service_type = MusicServiceType(service)
+            service_obj = await ctx.service_manager.initialize_service(service_type)
+            
+            click.echo(f"✅ Successfully connected to {service.replace('_', ' ').title()}!")
+            
+            # Get user info
+            user = await service_obj.get_current_user()
+            if user:
+                click.echo(f"👤 Logged in as: {user.get('display_name', user.get('name', 'Unknown'))}")
+            
+            return True
+            
+        except MusicServiceError as e:
+            click.echo(e.get_formatted_error())
+            return False
+        except Exception as e:
+            click.echo(f"❌ Unexpected error: {e}")
+            return False
+    
+    success = asyncio.run(test_service())
+    if success:
+        click.echo(f"🎉 {service.replace('_', ' ').title()} is ready to use!")
+
+
+@cli.command()
+@click.option('--service', type=click.Choice(['spotify', 'youtube_music', 'amazon_music']), 
+              help='Music service to use (will prompt if not specified)')
+@click.option('--reference-playlist', help='Reference playlist ID (will use config if not specified)')
+@click.option('--size', default=30, help='Number of tracks to discover')
+@click.pass_obj
+def discover(ctx: CLIContext, service: Optional[str], reference_playlist: Optional[str], size: int):
+    """🔍 Discover new music based on your taste profile."""
+    async def run_discovery():
+        nonlocal reference_playlist  # Allow modification of outer scope variable
+        try:
+            # Select service
+            if not service:
+                service_type = await _interactive_service_selection(ctx, require_discovery=True)
+            else:
+                service_type = MusicServiceType(service)
+            
+            click.echo(f"🔍 Discovering new music with {service_type.value.replace('_', ' ').title()}")
+            
+            # Initialize service
+            await ctx.service_manager.initialize_service(service_type)
+            discovery_engine = ctx.service_manager.get_discovery_engine(service_type)
+            
+            # Get reference playlist
+            if reference_playlist is None:
+                config = ctx.service_manager._load_service_config(service_type)
+                reference_playlist = config.get('REFERENCE_PLAYLIST_ID')
+            
+            if not reference_playlist or reference_playlist == 'your_playlist_id_here':
+                raise MusicServiceError(
+                    "No reference playlist specified",
+                    suggestions=[
+                        "Add --reference-playlist PLAYLIST_ID to the command",
+                        f"Configure REFERENCE_PLAYLIST_ID in your {service_type.value}.env file",
+                        f"Run: python main.py setup {service_type.value}"
+                    ]
+                )
+            
+            # Discover music
+            click.echo(f"🎵 Analyzing your taste from playlist: {reference_playlist}")
+            result = await discovery_engine.discover_new_playlist(reference_playlist, size)
+            
+            # Display results
+            click.echo(f"\n🎉 Discovery completed!")
+            playlist_name = result.get('playlist_name') or result.get('name', 'Unknown')
+            playlist_url = result.get('playlist_url') or result.get('external_url', 'N/A')
+            track_count = len(result.get('tracks', []))
+            
+            click.echo(f"📝 New Playlist: {playlist_name}")
+            click.echo(f"🎵 Tracks Discovered: {track_count}")
+            click.echo(f"🔗 Listen: {playlist_url}")
+            
+            if 'taste_profile' in result:
+                profile = result['taste_profile']
+                click.echo(f"\n🎯 Your Taste Profile:")
+                if 'genres' in profile:
+                    click.echo(f"🎸 Genres: {', '.join(profile['genres'][:5])}")
+                if 'artists_analyzed' in profile:
+                    click.echo(f"👥 Artists Analyzed: {profile['artists_analyzed']}")
+            
+        except MusicServiceError as e:
+            click.echo(e.get_formatted_error())
+        except Exception as e:
+            click.echo(f"❌ Discovery failed: {e}")
+            logger.exception("Discovery error")
+    
+    asyncio.run(run_discovery())
+
+
+@cli.command()
+@click.option('--service', type=click.Choice(['spotify', 'youtube_music', 'amazon_music']), 
+              help='Music service to use (will prompt if not specified)')
+@click.option('--reference-playlist', help='Reference playlist ID (will use config if not specified)')
+@click.option('--size', default=30, help='Number of tracks to curate')
+@click.pass_obj
+def curate(ctx: CLIContext, service: Optional[str], reference_playlist: Optional[str], size: int):
+    """🎵 Create smart curated playlist from your existing favorites."""
+    async def run_curation():
+        nonlocal reference_playlist  # Allow modification of outer scope variable
+        try:
+            # Select service
+            if not service:
+                service_type = await _interactive_service_selection(ctx, require_curator=True)
+            else:
+                service_type = MusicServiceType(service)
+            
+            click.echo(f"🎵 Creating curated playlist with {service_type.value.replace('_', ' ').title()}")
+            
+            # Initialize service
+            await ctx.service_manager.initialize_service(service_type)
+            curator = ctx.service_manager.get_curator(service_type)
+            
+            # Get reference playlist
+            if reference_playlist is None:
+                config = ctx.service_manager._load_service_config(service_type)
+                reference_playlist = config.get('REFERENCE_PLAYLIST_ID')
+            
+            if not reference_playlist or reference_playlist == 'your_playlist_id_here':
+                raise MusicServiceError(
+                    "No reference playlist specified",
+                    suggestions=[
+                        "Add --reference-playlist PLAYLIST_ID to the command",
+                        f"Configure REFERENCE_PLAYLIST_ID in your {service_type.value}.env file",
+                        f"Run: python main.py setup {service_type.value}"
+                    ]
+                )
+            
+            # Generate curated playlist
+            click.echo(f"🎵 Curating from playlist: {reference_playlist}")
+            result = await curator.generate_curated_playlist(reference_playlist, size)
+            
+            # Display results
+            click.echo(f"\n🎉 Curation completed!")
+            playlist_name = result.get('playlist_name') or result.get('name', 'Unknown')
+            playlist_url = result.get('playlist_url') or result.get('external_url', 'N/A')
+            track_count = len(result.get('tracks', []))
+            
+            click.echo(f"📝 Playlist: {playlist_name}")
+            click.echo(f"🎵 Tracks Added: {track_count}")
+            click.echo(f"🔗 Listen: {playlist_url}")
+            
+            if 'freshness_score' in result:
+                freshness = result['freshness_score']
+                click.echo(f"✨ Freshness Score: {freshness:.1f}%")
+                
+                # Show additional stats if available
+                if 'stats' in result:
+                    stats = result['stats']
+                    if 'freshness_details' in stats:
+                        click.echo(f"   └ {stats['freshness_details']}")
+                    if 'unique_artists' in stats:
+                        click.echo(f"🎤 Unique Artists: {stats['unique_artists']}")
+            
+        except MusicServiceError as e:
+            click.echo(e.get_formatted_error())
+        except Exception as e:
+            click.echo(f"❌ Curation failed: {e}")
+            logger.exception("Curation error")
+    
+    asyncio.run(run_curation())
+
+
+@cli.command()
+@click.pass_obj
+def health(ctx: CLIContext):
+    """🔧 Check health of all configured services."""
+    async def check_health():
+        click.echo("🔧 Checking service health...\n")
+        
+        results = await ctx.service_manager.health_check_all()
+        
+        if not results:
+            click.echo("⚠️  No services are currently active")
+            click.echo("💡 Run 'python main.py status' to see configuration status")
+            return
+        
+        for service_name, (is_healthy, message) in results.items():
+            service_display = service_name.replace('_', ' ').title()
+            
+            if is_healthy:
+                click.echo(f"✅ {service_display}: {message}")
+            else:
+                click.echo(f"❌ {service_display}: {message}")
+        
+        # Summary
+        healthy_count = sum(1 for is_healthy, _ in results.values() if is_healthy)
+        total_count = len(results)
+        
+        click.echo(f"\n📊 Health Summary: {healthy_count}/{total_count} services healthy")
+    
+    asyncio.run(check_health())
+
+
+async def _interactive_service_selection(ctx: CLIContext, require_discovery: bool = False, require_curator: bool = False) -> MusicServiceType:
+    """Interactive service selection with validation."""
+    available_services = ctx.service_manager.get_available_services()
+    
+    if not available_services:
+        raise MusicServiceError(
+            "No music services are available",
+            suggestions=[
+                "Install service dependencies",
+                "Check that service modules are properly imported"
+            ]
+        )
+    
+    # Filter services based on requirements
+    valid_services = []
+    status_info = ctx.service_manager.get_service_status()
+    
+    for service_type in available_services:
+        info = status_info[service_type.value]
+        
+        # Check configuration
+        if not info['configured']:
+            continue
+        
+        # Check feature requirements
+        if require_discovery and not info['has_discovery']:
+            continue
+        if require_curator and not info['has_curator']:
+            continue
+        
+        valid_services.append(service_type)
+    
+    if not valid_services:
+        feature_name = "discovery" if require_discovery else "curation" if require_curator else "any features"
+        raise MusicServiceError(
+            f"No configured services support {feature_name}",
+            suggestions=[
+                "Run 'python main.py status' to see configuration status",
+                "Setup a service: python main.py setup <service>"
+            ]
+        )
+    
+    if len(valid_services) == 1:
+        return valid_services[0]
+    
+    # Interactive selection
+    click.echo("🎵 Multiple services available. Please choose:")
+    for i, service_type in enumerate(valid_services, 1):
+        service_name = service_type.value.replace('_', ' ').title()
+        click.echo(f"  {i}. {service_name}")
+    
+    while True:
+        try:
+            choice = click.prompt("Enter your choice", type=int)
+            if 1 <= choice <= len(valid_services):
+                return valid_services[choice - 1]
+            else:
+                click.echo(f"Please enter a number between 1 and {len(valid_services)}")
+        except (ValueError, click.Abort):
+            click.echo("Invalid choice. Please enter a number.")
+
+
+if __name__ == '__main__':
+    cli() 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,21 @@
+# Core dependencies
 spotipy==2.23.0
-schedule==1.2.0
 python-dotenv==1.0.0
 pydantic==2.5.0
 pydantic-settings==2.1.0
 loguru==0.7.2
-click==8.1.7 
+click==8.1.7
+
+# YouTube Music dependencies
+ytmusicapi==1.10.3
+google-auth==2.17.3
+google-auth-oauthlib==1.0.0
+google-auth-httplib2==0.1.0
+google-api-python-client==2.100.0
+
+# Optional: Amazon Music (requires separate installation)  
+# boto3==1.34.0
+
+# Development dependencies
+# pytest==7.4.0
+# pytest-asyncio==0.21.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 # Core dependencies
 spotipy==2.23.0
 python-dotenv==1.0.0
-pydantic==2.5.0
-pydantic-settings==2.1.0
 loguru==0.7.2
 click==8.1.7
 

--- a/service_manager.py
+++ b/service_manager.py
@@ -1,0 +1,344 @@
+"""Service manager for handling multiple music service integrations."""
+
+import os
+from typing import Dict, List, Any, Optional, Type, Tuple
+from pathlib import Path
+
+from loguru import logger
+
+from base_music_service import BaseMusicService, MusicServiceType, BaseDiscoveryEngine, BaseCurator
+
+
+class MusicServiceError(Exception):
+    """Custom exception for music service errors with user-friendly messages."""
+    
+    def __init__(self, message: str, suggestions: List[str] = None, service_type: str = None):
+        self.message = message
+        self.suggestions = suggestions or []
+        self.service_type = service_type
+        super().__init__(message)
+    
+    def get_formatted_error(self) -> str:
+        """Get a formatted error message with suggestions."""
+        error_msg = f"❌ {self.message}"
+        
+        if self.service_type:
+            error_msg = f"❌ [{self.service_type.upper()}] {self.message}"
+        
+        if self.suggestions:
+            error_msg += "\n\n💡 Suggestions:"
+            for i, suggestion in enumerate(self.suggestions, 1):
+                error_msg += f"\n  {i}. {suggestion}"
+        
+        return error_msg
+
+
+class ServiceManager:
+    """Manages multiple music service integrations with user-friendly setup."""
+    
+    def __init__(self, config_dir: Path = None):
+        """Initialize the service manager."""
+        self.config_dir = config_dir or Path.cwd()  # Use current working directory for transparency
+        
+        # Registry of available services
+        self._service_registry: Dict[MusicServiceType, Type[BaseMusicService]] = {}
+        self._discovery_registry: Dict[MusicServiceType, Type[BaseDiscoveryEngine]] = {}
+        self._curator_registry: Dict[MusicServiceType, Type[BaseCurator]] = {}
+        
+        # Current active services
+        self._active_services: Dict[MusicServiceType, BaseMusicService] = {}
+    
+    def register_service(
+        self, 
+        service_type: MusicServiceType, 
+        service_class: Type[BaseMusicService],
+        discovery_class: Type[BaseDiscoveryEngine] = None,
+        curator_class: Type[BaseCurator] = None
+    ):
+        """Register a music service implementation."""
+        self._service_registry[service_type] = service_class
+        
+        if discovery_class:
+            self._discovery_registry[service_type] = discovery_class
+        
+        if curator_class:
+            self._curator_registry[service_type] = curator_class
+        
+        logger.info(f"Registered service: {service_type.value}")
+    
+    def get_available_services(self) -> List[MusicServiceType]:
+        """Get list of available (registered) services."""
+        return list(self._service_registry.keys())
+    
+    def get_service_status(self) -> Dict[str, Dict[str, Any]]:
+        """Get status of all registered services."""
+        status = {}
+        
+        for service_type in self._service_registry:
+            config = self._load_service_config(service_type)
+            service_class = self._service_registry[service_type]
+            
+            # Create temporary instance for validation
+            try:
+                temp_service = service_class(config)
+                is_valid, errors = temp_service.validate_config()
+                
+                status[service_type.value] = {
+                    "configured": is_valid,
+                    "errors": errors,
+                    "has_discovery": service_type in self._discovery_registry,
+                    "has_curator": service_type in self._curator_registry,
+                    "config_file": self._get_config_file_path(service_type)
+                }
+            except Exception as e:
+                status[service_type.value] = {
+                    "configured": False,
+                    "errors": [str(e)],
+                    "has_discovery": service_type in self._discovery_registry,
+                    "has_curator": service_type in self._curator_registry,
+                    "config_file": self._get_config_file_path(service_type)
+                }
+        
+        return status
+    
+    async def initialize_service(self, service_type: MusicServiceType) -> BaseMusicService:
+        """Initialize and authenticate a music service."""
+        if service_type not in self._service_registry:
+            raise MusicServiceError(
+                f"Service '{service_type.value}' is not registered",
+                suggestions=[
+                    f"Available services: {', '.join([s.value for s in self.get_available_services()])}",
+                    "Check if the service module is properly imported"
+                ]
+            )
+        
+        # Check if already initialized
+        if service_type in self._active_services:
+            return self._active_services[service_type]
+        
+        # Load configuration
+        config = self._load_service_config(service_type)
+        
+        # Validate configuration
+        service_class = self._service_registry[service_type]
+        temp_service = service_class(config)
+        is_valid, errors = temp_service.validate_config()
+        
+        if not is_valid:
+            config_file = self._get_config_file_path(service_type)
+            raise MusicServiceError(
+                f"Invalid configuration for {service_type.value}",
+                suggestions=[
+                    f"Check your configuration file: {config_file}",
+                    f"Run: python main.py setup {service_type.value}",
+                    "Ensure all required API credentials are provided"
+                ] + [f"• {error}" for error in errors],
+                service_type=service_type.value
+            )
+        
+        # Initialize and authenticate
+        try:
+            service = service_class(config)
+            auth_success = await service.authenticate()
+            
+            if not auth_success:
+                raise MusicServiceError(
+                    f"Failed to authenticate with {service_type.value}",
+                    suggestions=self._get_auth_suggestions(service_type),
+                    service_type=service_type.value
+                )
+            
+            self._active_services[service_type] = service
+            logger.info(f"Successfully initialized {service_type.value}")
+            return service
+            
+        except Exception as e:
+            if isinstance(e, MusicServiceError):
+                raise
+            
+            raise MusicServiceError(
+                f"Failed to initialize {service_type.value}: {str(e)}",
+                suggestions=self._get_troubleshooting_suggestions(service_type),
+                service_type=service_type.value
+            )
+    
+    def get_discovery_engine(self, service_type: MusicServiceType) -> BaseDiscoveryEngine:
+        """Get discovery engine for a service."""
+        if service_type not in self._discovery_registry:
+            raise MusicServiceError(
+                f"Discovery engine not available for {service_type.value}",
+                suggestions=[
+                    "This service may not support music discovery",
+                    "Try using the curator instead"
+                ]
+            )
+        
+        if service_type not in self._active_services:
+            raise MusicServiceError(
+                f"Service {service_type.value} is not initialized",
+                suggestions=[f"Run: python main.py init {service_type.value}"]
+            )
+        
+        discovery_class = self._discovery_registry[service_type]
+        return discovery_class(self._active_services[service_type])
+    
+    def get_curator(self, service_type: MusicServiceType) -> BaseCurator:
+        """Get curator for a service."""
+        if service_type not in self._curator_registry:
+            raise MusicServiceError(
+                f"Curator not available for {service_type.value}",
+                suggestions=[
+                    "This service may not support curation",
+                    "Try using the discovery engine instead"
+                ]
+            )
+        
+        if service_type not in self._active_services:
+            raise MusicServiceError(
+                f"Service {service_type.value} is not initialized",
+                suggestions=[f"Run: python main.py init {service_type.value}"]
+            )
+        
+        curator_class = self._curator_registry[service_type]
+        return curator_class(self._active_services[service_type])
+    
+    def _load_service_config(self, service_type: MusicServiceType) -> Dict[str, Any]:
+        """Load configuration for a specific service."""
+        config_file = self._get_config_file_path(service_type)
+        
+        if not config_file.exists():
+            return {}
+        
+        # Load from .env style file
+        config = {}
+        try:
+            with open(config_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#') and '=' in line:
+                        key, value = line.split('=', 1)
+                        config[key.strip()] = value.strip()
+        except Exception as e:
+            logger.warning(f"Failed to load config for {service_type.value}: {e}")
+        
+        return config
+    
+    def _get_config_file_path(self, service_type: MusicServiceType) -> Path:
+        """Get config file path for a service."""
+        return self.config_dir / f"{service_type.value}.env"
+    
+    def _get_auth_suggestions(self, service_type: MusicServiceType) -> List[str]:
+        """Get authentication troubleshooting suggestions for a service."""
+        base_suggestions = [
+            "Verify your API credentials are correct",
+            "Check if your API keys have expired",
+            "Ensure your application has the required permissions"
+        ]
+        
+        if service_type == MusicServiceType.SPOTIFY:
+            return base_suggestions + [
+                "Check your Spotify redirect URI matches exactly: http://127.0.0.1:8080/callback",
+                "Verify your Spotify app is not in development mode restrictions",
+                "Try refreshing your Spotify token cache"
+            ]
+        elif service_type == MusicServiceType.YOUTUBE_MUSIC:
+            return base_suggestions + [
+                "Ensure you have a YouTube Music subscription",
+                "Check if your OAuth consent screen is configured",
+                "Verify the OAuth redirect URI is correct"
+            ]
+        elif service_type == MusicServiceType.AMAZON_MUSIC:
+            return base_suggestions + [
+                "Verify your Amazon Music subscription is active",
+                "Check your Amazon Developer account credentials",
+                "Ensure your app is approved for Music API access"
+            ]
+        
+        return base_suggestions
+    
+    def _get_troubleshooting_suggestions(self, service_type: MusicServiceType) -> List[str]:
+        """Get general troubleshooting suggestions for a service."""
+        return [
+            f"Check if {service_type.value} is experiencing outages",
+            "Verify your internet connection",
+            "Try clearing the service cache",
+            f"Re-run the setup: python main.py setup {service_type.value}",
+            "Check the logs for detailed error information"
+        ]
+    
+    def create_service_config_template(self, service_type: MusicServiceType) -> str:
+        """Create a configuration template for a service."""
+        config_file = self._get_config_file_path(service_type)
+        
+        if service_type == MusicServiceType.SPOTIFY:
+            template = """# Spotify Configuration
+# Get these from https://developer.spotify.com/dashboard/
+
+# Required: Your Spotify app credentials
+SPOTIFY_CLIENT_ID=your_client_id_here
+SPOTIFY_CLIENT_SECRET=your_client_secret_here
+
+# Required: Redirect URI (must match your Spotify app settings)
+SPOTIFY_REDIRECT_URI=http://127.0.0.1:8080/callback
+
+# Required: Your reference workout playlist ID
+# Get this from Spotify playlist URL: spotify:playlist:PLAYLIST_ID
+REFERENCE_PLAYLIST_ID=your_playlist_id_here
+
+# Optional: Playlist settings
+TARGET_PLAYLIST_NAME=Daily Workout Mix
+PLAYLIST_SIZE=30
+"""
+        elif service_type == MusicServiceType.YOUTUBE_MUSIC:
+            template = """# YouTube Music Configuration
+# Get these from https://console.developers.google.com/
+
+# Required: Your Google OAuth credentials
+YOUTUBE_CLIENT_ID=your_client_id_here
+YOUTUBE_CLIENT_SECRET=your_client_secret_here
+YOUTUBE_REDIRECT_URI=http://localhost:8080/callback
+
+# Required: Your reference playlist ID
+REFERENCE_PLAYLIST_ID=your_playlist_id_here
+
+# Optional: Playlist settings
+TARGET_PLAYLIST_NAME=Daily Workout Mix
+PLAYLIST_SIZE=30
+"""
+        elif service_type == MusicServiceType.AMAZON_MUSIC:
+            template = """# Amazon Music Configuration
+# Get these from https://developer.amazon.com/
+
+# Required: Your Amazon Music API credentials
+AMAZON_CLIENT_ID=your_client_id_here
+AMAZON_CLIENT_SECRET=your_client_secret_here
+AMAZON_REDIRECT_URI=http://localhost:8080/callback
+
+# Required: Your reference playlist ID
+REFERENCE_PLAYLIST_ID=your_playlist_id_here
+
+# Optional: Playlist settings
+TARGET_PLAYLIST_NAME=Daily Workout Mix
+PLAYLIST_SIZE=30
+"""
+        else:
+            template = f"# {service_type.value.title()} Configuration\n# Add your configuration here\n"
+        
+        # Write template to file
+        with open(config_file, 'w') as f:
+            f.write(template)
+        
+        return str(config_file)
+    
+    async def health_check_all(self) -> Dict[str, Tuple[bool, str]]:
+        """Perform health check on all active services."""
+        results = {}
+        
+        for service_type, service in self._active_services.items():
+            try:
+                is_healthy, message = await service.health_check()
+                results[service_type.value] = (is_healthy, message)
+            except Exception as e:
+                results[service_type.value] = (False, f"Health check failed: {str(e)}")
+        
+        return results 

--- a/service_manager.py
+++ b/service_manager.py
@@ -304,6 +304,10 @@ REFERENCE_PLAYLIST_ID=your_playlist_id_here
 # Optional: Playlist settings
 TARGET_PLAYLIST_NAME=Daily Workout Mix
 PLAYLIST_SIZE=30
+ 
+ # Optional: YTMusic headers file to access likes/library (export from browser)
+ # Example path: /Users/you/ytmusic_headers.json
+ YTMUSIC_HEADERS_FILE=
 """
         elif service_type == MusicServiceType.AMAZON_MUSIC:
             template = """# Amazon Music Configuration

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services package for music service implementations.""" 

--- a/services/spotify_curator.py
+++ b/services/spotify_curator.py
@@ -1,0 +1,397 @@
+"""Spotify curator implementation."""
+
+import json
+import random
+from datetime import datetime
+from typing import Dict, List, Any
+from pathlib import Path
+from collections import Counter
+
+from loguru import logger
+
+from base_music_service import BaseCurator, TrackInfo
+from services.spotify_service import SpotifyService
+
+
+class SpotifyCurator(BaseCurator):
+    """Spotify-specific implementation of playlist curation."""
+    
+    def __init__(self, music_service: SpotifyService):
+        """Initialize with Spotify service."""
+        super().__init__(music_service)
+        self.spotify = music_service
+        self.history_file = Path.cwd() / "spotify_usage_history.json"
+    
+    async def generate_curated_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Generate a curated playlist from existing Spotify tracks."""
+        try:
+            logger.info("Generating curated Spotify playlist with enhanced variety algorithms")
+            
+            # Get reference playlist tracks
+            reference_tracks = await self.spotify.get_playlist_tracks(reference_playlist_id)
+            logger.info(f"Reference playlist has {len(reference_tracks)} tracks")
+            
+            if not reference_tracks:
+                raise ValueError("Reference playlist is empty")
+            
+            # Load usage history
+            usage_history = self._load_usage_history()
+            
+            # Smart selection with variety optimization
+            selected_tracks = await self._smart_select_with_history(reference_tracks, usage_history, target_size, reference_playlist_id)
+            
+            # Update usage history
+            self._update_usage_history(selected_tracks, usage_history)
+            
+            logger.info(f"Selected {len(selected_tracks)} tracks with optimized variety")
+            
+            # Create playlist
+            today = datetime.now()
+            playlist_name = f"Daily Workout Mix - {today.strftime('%Y-%m-%d')}"
+            
+            # Check if playlist exists
+            existing_playlist = await self.spotify.find_playlist_by_name(playlist_name)
+            if existing_playlist:
+                playlist_info = existing_playlist
+                logger.info(f"Found existing playlist: {playlist_name}")
+            else:
+                description = f"Daily workout playlist with maximum variety, curated on {today.strftime('%B %d, %Y')}."
+                playlist_info = await self.spotify.create_playlist(playlist_name, description)
+                logger.info(f"Created new playlist: {playlist_name}")
+            
+            # Update playlist
+            track_uris = [track.uri for track in selected_tracks]
+            await self.spotify.update_playlist_tracks(playlist_info.id, track_uris)
+            
+            # Also update main playlist
+            main_playlist = await self.spotify.find_playlist_by_name("Daily Workout Mix")
+            if main_playlist:
+                await self.spotify.update_playlist_tracks(main_playlist.id, track_uris)
+                logger.info("Updated main Daily Workout Mix playlist")
+            
+            # Calculate freshness stats
+            stats = self._calculate_freshness_stats(selected_tracks, usage_history)
+            
+            return {
+                'playlist_id': playlist_info.id,
+                'playlist_name': playlist_info.name,
+                'playlist_url': playlist_info.external_url,
+                'tracks': selected_tracks,
+                'freshness_score': stats['freshness_score'],
+                'stats': stats,
+                'total_tracks_available': len(reference_tracks)
+            }
+            
+        except Exception as e:
+            logger.error(f"Curation failed: {e}")
+            raise
+    
+    async def get_usage_stats(self) -> Dict[str, Any]:
+        """Get usage statistics for the Spotify curator."""
+        usage_history = self._load_usage_history()
+        
+        if not usage_history:
+            return {
+                'total_tracks_used': 0,
+                'total_playlists_generated': 0,
+                'most_used_tracks': [],
+                'least_used_tracks': [],
+                'usage_distribution': {}
+            }
+        
+        track_usage_counts = {}
+        for track_id, usage_data in usage_history.items():
+            track_usage_counts[track_id] = usage_data['count']
+        
+        # Sort by usage count
+        sorted_usage = sorted(track_usage_counts.items(), key=lambda x: x[1])
+        
+        return {
+            'total_tracks_used': len(track_usage_counts),
+            'total_playlists_generated': max(usage_data.get('count', 0) for usage_data in usage_history.values()) if usage_history else 0,
+            'most_used_tracks': sorted_usage[-5:],  # Top 5 most used
+            'least_used_tracks': sorted_usage[:5],   # Top 5 least used
+            'usage_distribution': self._get_usage_distribution(track_usage_counts)
+        }
+    
+    def _load_usage_history(self) -> Dict[str, Any]:
+        """Load usage history from file."""
+        try:
+            if self.history_file.exists():
+                with open(self.history_file, 'r') as f:
+                    return json.load(f)
+        except Exception as e:
+            logger.warning(f"Could not load usage history: {e}")
+        
+        return {}
+    
+    def _save_usage_history(self, history: Dict[str, Any]) -> None:
+        """Save usage history to file."""
+        try:
+            with open(self.history_file, 'w') as f:
+                json.dump(history, f, indent=2)
+        except Exception as e:
+            logger.error(f"Could not save usage history: {e}")
+    
+    async def _smart_select_with_history(self, reference_tracks: List[TrackInfo], usage_history: Dict[str, Any], target_size: int, reference_playlist_id: str = None) -> List[TrackInfo]:
+        """Select tracks with anti-repetition algorithm."""
+        # Score each track based on usage history and variety factors
+        track_scores = []
+        
+        # Get artist distribution in reference playlist
+        artist_counts = Counter()
+        for track in reference_tracks:
+            # Handle multiple artists
+            artists = [artist.strip() for artist in track.artist.split(',')]
+            for artist in artists:
+                artist_counts[artist] += 1
+        
+        for track in reference_tracks:
+            score = self._calculate_track_score(track, usage_history, artist_counts)
+            track_scores.append((track, score))
+        
+        # Sort by score (higher is better)
+        track_scores.sort(key=lambda x: x[1], reverse=True)
+        
+        # Select tracks with artist variety constraints - but ONLY good scores
+        selected_tracks = []
+        used_artists = set()
+        
+        for track, score in track_scores:
+            if len(selected_tracks) >= target_size:
+                break
+            
+            # STRICT: Only consider tracks with decent scores (not recently used)
+            if score < 5:  # Skip tracks with very poor scores (recently used)
+                continue
+                
+            # Check artist variety
+            track_artists = {artist.strip() for artist in track.artist.split(',')}
+            
+            # Allow track if it doesn't repeat artists too much
+            artist_overlap = len(track_artists & used_artists)
+            max_allowed_overlap = 1  # Allow some artist repetition but limit it
+            
+            if artist_overlap <= max_allowed_overlap or len(selected_tracks) < target_size // 2:
+                selected_tracks.append(track)
+                used_artists.update(track_artists)
+        
+        # If we don't have enough tracks, be MUCH more selective about fallback
+        if len(selected_tracks) < target_size:
+            # Only consider tracks that haven't been heavily used
+            acceptable_tracks = []
+            for track, score in track_scores:
+                if track not in selected_tracks and score > 10:  # Only tracks with decent scores
+                    track_usage = usage_history.get(track.id, {})
+                    hours_since_last = float('inf')
+                    
+                    if track_usage.get('last_used'):
+                        try:
+                            last_used = datetime.fromisoformat(track_usage['last_used'])
+                            hours_since_last = (datetime.now() - last_used).total_seconds() / 3600
+                        except:
+                            pass
+                    
+                    # Only add if not used recently or not used much
+                    usage_count = track_usage.get('count', 0)
+                    if hours_since_last >= 12 or usage_count <= 2:  # At least 12 hours old OR used ≤2 times
+                        acceptable_tracks.append(track)
+            
+            # Add acceptable tracks up to target size
+            needed = target_size - len(selected_tracks)
+            selected_tracks.extend(acceptable_tracks[:needed])
+            
+            # If STILL not enough, DISCOVER NEW TRACKS from the internet!
+            if len(selected_tracks) < target_size:
+                logger.info(f"🔍 Only found {len(selected_tracks)} tracks from reference playlist. Discovering fresh tracks from the internet...")
+                
+                # Import and use discovery engine
+                try:
+                    from .spotify_discovery import SpotifyDiscoveryEngine
+                    discovery_engine = SpotifyDiscoveryEngine(self.music_service)
+                    
+                    # DYNAMICALLY analyze the reference playlist to learn taste
+                    logger.info("🔍 Analyzing your reference playlist to learn your taste...")
+                    taste_profile = await discovery_engine.analyze_taste_profile(reference_playlist_id)
+                    
+                    logger.info(f"📊 Found genres: {', '.join(taste_profile['genres'][:5])}")
+                    logger.info(f"🎤 Found {len(taste_profile['artist_infos'])} artists to use as seeds")
+                    
+                    # Discover fresh tracks based on ACTUAL analyzed taste
+                    needed = target_size - len(selected_tracks)
+                    logger.info(f"🎵 Discovering {needed} fresh tracks based on YOUR actual taste profile...")
+                    
+                    if taste_profile['genres'] or taste_profile['artist_infos']:
+                        fresh_tracks = await discovery_engine._discover_tracks(taste_profile, needed * 2)  # Get extra for filtering
+                    else:
+                        logger.warning("No source tracks available for taste analysis")
+                        fresh_tracks = []
+                    
+                    # Filter out any tracks we already have in usage history OR reference playlist
+                    reference_track_names = {track.name.lower() for track in reference_tracks}
+                    reference_track_ids = {track.id for track in reference_tracks}
+                    
+                    # Words that indicate slow/mellow tracks to avoid
+                    slow_words = {'interview', 'interlude', 'ballad', 'acoustic', 'unplugged', 
+                                 'slow', 'soft', 'quiet', 'gentle', 'mellow', 'calm', 'peaceful',
+                                 'silence', 'whisper', 'lullaby', 'serenade', 'tender'}
+                    
+                    truly_fresh = []
+                    for track in fresh_tracks:
+                        track_name_lower = track.name.lower()
+                        
+                        # Check if track name contains slow/mellow indicators
+                        has_slow_words = any(word in track_name_lower for word in slow_words)
+                        
+                        # Block if in usage history, reference playlist, already selected, or sounds slow
+                        if (track.id not in usage_history and 
+                            track.id not in reference_track_ids and
+                            track.name.lower() not in reference_track_names and
+                            track not in selected_tracks and
+                            not has_slow_words):
+                            truly_fresh.append(track)
+                            if len(truly_fresh) >= needed:
+                                break
+                    
+                    logger.info(f"✨ Found {len(truly_fresh)} completely fresh tracks from internet discovery")
+                    selected_tracks.extend(truly_fresh)
+                    
+                except Exception as e:
+                    logger.error(f"Failed to discover fresh tracks: {e}")
+                    logger.warning(f"Could only find {len(selected_tracks)} fresh tracks out of {target_size} requested. Preferring quality over quantity.")
+        
+        # Shuffle to avoid predictable ordering
+        random.shuffle(selected_tracks)
+        
+        logger.info(f"Selected {len(selected_tracks)} tracks with variety score optimization")
+        return selected_tracks[:target_size]
+    
+    def _calculate_track_score(self, track: TrackInfo, usage_history: Dict[str, Any], artist_counts: Counter) -> float:
+        """Calculate a score for track selection (higher = more likely to be selected)."""
+        score = 100.0  # Base score
+        
+        # Factor 1: Usage frequency (less used = higher score)
+        track_usage = usage_history.get(track.id, {})
+        usage_count = track_usage.get('count', 0)
+        
+        # MUCH more aggressive penalties for recently used tracks
+        if usage_count == 0:
+            score += 80  # Huge bonus for never used tracks
+        elif usage_count == 1:
+            score += 40  # Good bonus for rarely used
+        elif usage_count == 2:
+            score += 15  # Small bonus for lightly used
+        elif usage_count == 3:
+            score -= 20  # Penalty for moderate use
+        else:
+            score -= usage_count * 15  # Heavy penalty for overuse
+        
+        # Factor 2: Time since last use - MUCH stricter
+        last_used = track_usage.get('last_used')
+        if last_used:
+            try:
+                last_used_date = datetime.fromisoformat(last_used)
+                hours_since = (datetime.now() - last_used_date).total_seconds() / 3600
+                
+                if hours_since < 12:  # Used in last 12 hours
+                    return 0.1  # Effectively block this track
+                elif hours_since < 24:  # Used today
+                    score -= 80  # Massive penalty
+                elif hours_since < 72:  # Used in last 3 days
+                    score -= 50  # Heavy penalty
+                elif hours_since < 168:  # Used this week
+                    score -= 25  # Moderate penalty
+                else:  # Older than a week
+                    days_since = hours_since / 24
+                    score += min(days_since * 3, 50)  # Bonus for aging
+            except:
+                pass
+        else:
+            score += 30  # Bonus for tracks never used
+        
+        # Factor 3: Artist variety (prefer less common artists in the reference playlist)
+        track_artists = [artist.strip() for artist in track.artist.split(',')]
+        for artist in track_artists:
+            artist_frequency = artist_counts.get(artist, 1)
+            if artist_frequency == 1:
+                score += 15  # Bigger bonus for unique artists
+            elif artist_frequency <= 3:
+                score += 8   # Good bonus for less common artists
+            else:
+                score -= 5   # Penalty for very common artists
+        
+        # Factor 4: Track popularity (slight preference for popular tracks)
+        if track.popularity:
+            score += track.popularity * 0.1
+        
+        # Factor 5: Randomization factor to avoid deterministic selection
+        score += random.uniform(-3, 3)
+        
+        return max(score, 0.1)  # Ensure minimum score but allow very low ones
+    
+    def _update_usage_history(self, selected_tracks: List[TrackInfo], usage_history: Dict[str, Any]) -> None:
+        """Update usage history with newly selected tracks."""
+        current_time = datetime.now().isoformat()
+        
+        for track in selected_tracks:
+            if track.id not in usage_history:
+                usage_history[track.id] = {
+                    'count': 0,
+                    'first_used': current_time,
+                    'track_name': track.name,
+                    'artist': track.artist
+                }
+            
+            usage_history[track.id]['count'] += 1
+            usage_history[track.id]['last_used'] = current_time
+        
+        # Save updated history
+        self._save_usage_history(usage_history)
+        logger.info(f"Updated usage history for {len(selected_tracks)} tracks")
+    
+    def _calculate_freshness_stats(self, selected_tracks: List[TrackInfo], usage_history: Dict[str, Any]) -> Dict[str, Any]:
+        """Calculate freshness statistics for the selected tracks."""
+        never_used = 0
+        rarely_used = 0  # 1-2 times
+        frequently_used = 0  # 3+ times
+        
+        for track in selected_tracks:
+            usage_count = usage_history.get(track.id, {}).get('count', 0)
+            
+            if usage_count == 0:
+                never_used += 1
+            elif usage_count <= 2:
+                rarely_used += 1
+            else:
+                frequently_used += 1
+        
+        total_tracks = len(selected_tracks)
+        if total_tracks == 0:
+            freshness_score = 0
+        else:
+            freshness_score = ((never_used * 1.0) + (rarely_used * 0.7) + (frequently_used * 0.3)) / total_tracks * 100
+        
+        return {
+            'freshness_score': freshness_score,
+            'never_used': never_used,
+            'rarely_used': rarely_used,
+            'frequently_used': frequently_used,
+            'total_tracks': total_tracks,
+            'distribution': {
+                'never_used_pct': (never_used / total_tracks) * 100 if total_tracks > 0 else 0,
+                'rarely_used_pct': (rarely_used / total_tracks) * 100 if total_tracks > 0 else 0,
+                'frequently_used_pct': (frequently_used / total_tracks) * 100 if total_tracks > 0 else 0
+            }
+        }
+    
+    def _get_usage_distribution(self, track_usage_counts: Dict[str, int]) -> Dict[str, int]:
+        """Get distribution of usage counts."""
+        distribution = {}
+        
+        for count in track_usage_counts.values():
+            if count in distribution:
+                distribution[count] += 1
+            else:
+                distribution[count] = 1
+        
+        return distribution 

--- a/services/spotify_discovery.py
+++ b/services/spotify_discovery.py
@@ -1,0 +1,439 @@
+"""Spotify discovery engine implementation."""
+
+import random
+from datetime import datetime
+from typing import Dict, List, Any, Set
+from collections import Counter
+
+from loguru import logger
+
+from base_music_service import BaseDiscoveryEngine, TrackInfo, ArtistInfo
+from services.spotify_service import SpotifyService
+
+
+class SpotifyDiscoveryEngine(BaseDiscoveryEngine):
+    """Spotify-specific implementation of music discovery."""
+    
+    def __init__(self, music_service: SpotifyService):
+        """Initialize with Spotify service."""
+        super().__init__(music_service)
+        self.spotify = music_service
+    
+    async def discover_new_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Discover new tracks based on a Spotify reference playlist."""
+        try:
+            logger.info("Starting Spotify music discovery process")
+            
+            # Step 1: Analyze taste profile
+            taste_profile = await self.analyze_taste_profile(reference_playlist_id)
+            logger.info(f"Analyzed taste profile: {len(taste_profile['artists'])} artists, {len(taste_profile['genres'])} genres")
+            
+            # Step 2: Discover new tracks
+            new_tracks = await self._discover_tracks(taste_profile, target_size * 3)  # Get more than needed for better selection
+            logger.info(f"Discovered {len(new_tracks)} potential new tracks")
+            
+            # Step 3: Filter out known tracks
+            filtered_tracks = await self._filter_unknown_tracks(new_tracks, taste_profile['known_track_ids'])
+            logger.info(f"After filtering known tracks: {len(filtered_tracks)} truly new tracks")
+            
+            if not filtered_tracks:
+                raise ValueError("No new tracks discovered. Try expanding your reference playlist or check back later.")
+            
+            # Step 4: Select best tracks for playlist
+            selected_tracks = self._select_best_tracks(filtered_tracks, target_size)
+            
+            # Step 5: Create discovery playlist
+            result = await self._create_discovery_playlist(selected_tracks, taste_profile)
+            
+            logger.info(f"Successfully created discovery playlist with {len(selected_tracks)} new tracks")
+            return result
+            
+        except Exception as e:
+            logger.error(f"Discovery failed: {e}")
+            raise
+    
+    async def analyze_taste_profile(self, reference_playlist_id: str) -> Dict[str, Any]:
+        """Analyze user's taste profile from Spotify reference playlist."""
+        # Get reference playlist tracks
+        reference_tracks = await self.spotify.get_playlist_tracks(reference_playlist_id)
+        
+        if not reference_tracks:
+            raise ValueError("Reference playlist is empty or inaccessible")
+        
+        logger.info(f"Analyzing taste from {len(reference_tracks)} reference tracks")
+        
+        # Extract unique artists
+        artists = []
+        for track in reference_tracks:
+            # Handle multiple artists (split by comma)
+            track_artists = [artist.strip() for artist in track.artist.split(',')]
+            artists.extend(track_artists)
+        
+        # Get detailed artist info and genres
+        unique_artists = list(set(artists))
+        artist_genres = []
+        artist_infos = []
+        
+        for artist_name in unique_artists[:50]:  # Limit to avoid rate limits
+            try:
+                # Search for artist to get ID
+                search_results = await self.spotify.search_tracks(f"artist:{artist_name}", limit=1)
+                if search_results:
+                    # Get the actual track to extract artist info
+                    track_data = self.spotify.client.track(search_results[0].id)
+                    if track_data and track_data['artists']:
+                        main_artist_id = track_data['artists'][0]['id']
+                        artist_info = await self.spotify.get_artist_info(main_artist_id)
+                        artist_infos.append(artist_info)
+                        artist_genres.extend(artist_info.genres)
+            except Exception as e:
+                logger.warning(f"Could not get artist info for {artist_name}: {e}")
+                continue
+        
+        # Count genres
+        genre_counts = Counter(artist_genres)
+        top_genres = [genre for genre, count in genre_counts.most_common(10)]
+        
+        # Get known track IDs (for filtering)
+        known_track_ids = {track.id for track in reference_tracks}
+        
+        # Also add user's saved tracks to known list
+        try:
+            saved_tracks = await self.spotify.get_user_saved_tracks(limit=50)
+            known_track_ids.update(track.id for track in saved_tracks)
+        except Exception as e:
+            logger.warning(f"Could not get saved tracks: {e}")
+        
+        taste_profile = {
+            'genres': top_genres,
+            'artists': unique_artists,
+            'artist_infos': artist_infos,
+            'known_track_ids': known_track_ids,
+            'reference_tracks': reference_tracks,
+            'artists_analyzed': len(artist_infos)
+        }
+        
+        logger.info(f"Taste profile: {len(top_genres)} genres, {len(unique_artists)} artists")
+        return taste_profile
+    
+    async def _discover_tracks(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+        """Discover new tracks using advanced Spotify discovery methods."""
+        discovered_tracks = []
+        
+        # Method 1: Spotify Recommendations API (MOST POWERFUL - millions of tracks)
+        recommendation_tracks = await self._get_spotify_recommendations(taste_profile, target_count)
+        discovered_tracks.extend(recommendation_tracks)
+        
+        # Method 2: Advanced genre + audio feature searches
+        feature_tracks = await self._search_by_audio_features(taste_profile, target_count // 2)
+        discovered_tracks.extend(feature_tracks)
+        
+        # Method 3: Genre-based search (expanded)
+        genre_tracks = await self._search_by_genres(taste_profile['genres'], target_count // 2)
+        discovered_tracks.extend(genre_tracks)
+        
+        # Method 4: Related artist exploration (expanded)
+        related_tracks = await self._find_related_artists_tracks(taste_profile['artist_infos'], target_count // 2)
+        discovered_tracks.extend(related_tracks)
+        
+        # Method 5: Similar track searches
+        similar_tracks = await self._search_similar_tracks(taste_profile, target_count // 3)
+        discovered_tracks.extend(similar_tracks)
+        
+        # Method 6: Workout-specific search (expanded)
+        workout_tracks = await self._search_workout_genres(taste_profile, target_count // 4)
+        discovered_tracks.extend(workout_tracks)
+        
+        # Method 7: Popularity tier searches (find hidden gems)
+        hidden_gems = await self._search_hidden_gems(taste_profile, target_count // 4)
+        discovered_tracks.extend(hidden_gems)
+        
+        # Remove duplicates while preserving order
+        seen_ids = set()
+        unique_tracks = []
+        for track in discovered_tracks:
+            if track.id not in seen_ids:
+                seen_ids.add(track.id)
+                unique_tracks.append(track)
+        
+        logger.info(f"Discovered {len(unique_tracks)} unique tracks from {len(discovered_tracks)} total searches")
+        return unique_tracks
+    
+    async def _search_by_genres(self, genres: List[str], target_count: int) -> List[TrackInfo]:
+        """Search for tracks by genre."""
+        tracks = []
+        
+        for genre in genres[:5]:  # Use top 5 genres
+            try:
+                # Search with genre filter
+                query = f"genre:{genre}"
+                search_limit = max(1, target_count // max(1, len(genres[:5])))  # Ensure minimum 1
+                genre_tracks = await self.spotify.search_tracks(query, limit=search_limit)
+                tracks.extend(genre_tracks)
+                
+                logger.info(f"Found {len(genre_tracks)} tracks for genre: {genre}")
+            except Exception as e:
+                logger.warning(f"Genre search failed for {genre}: {e}")
+        
+        return tracks
+    
+    async def _find_related_artists_tracks(self, artist_infos: List[ArtistInfo], target_count: int) -> List[TrackInfo]:
+        """Find tracks from artists related to user's favorites."""
+        tracks = []
+        
+        for artist_info in artist_infos[:10]:  # Use top 10 artists
+            try:
+                # Get related artists
+                related_artists = await self.spotify.get_related_artists(artist_info.id)
+                
+                # Get top tracks from related artists
+                for related_artist in related_artists[:3]:  # Top 3 related per artist
+                    try:
+                        artist_tracks = await self.spotify.get_artist_top_tracks(related_artist.id, limit=2)
+                        tracks.extend(artist_tracks)
+                    except Exception as e:
+                        logger.warning(f"Could not get tracks for related artist {related_artist.name}: {e}")
+                        
+            except Exception as e:
+                logger.warning(f"Could not get related artists for {artist_info.name}: {e}")
+        
+        logger.info(f"Found {len(tracks)} tracks from related artists")
+        return tracks
+    
+    async def _search_workout_genres(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+        """Search for workout music based on user's actual taste profile."""
+        tracks = []
+        
+        # Use the ACTUAL genres from the user's playlist
+        user_genres = taste_profile.get('genres', [])[:5]  # Top 5 genres
+        
+        if not user_genres:
+            # Fallback to general workout search if no genres found
+            user_genres = ['workout', 'rock', 'metal']
+        
+        # Create workout-focused searches based on USER'S genres
+        workout_searches = []
+        for genre in user_genres:
+            # Add workout/energy modifiers to user's genres
+            workout_searches.extend([
+                f"{genre} workout high energy",
+                f"{genre} aggressive fast tempo",
+                f"{genre} pump up intense"
+            ])
+        
+        per_query = max(1, target_count // len(workout_searches))
+        
+        for query in workout_searches[:10]:  # Limit to 10 searches
+            try:
+                query_tracks = await self.spotify.search_tracks(query, limit=per_query)
+                tracks.extend(query_tracks)
+            except Exception as e:
+                logger.warning(f"Workout search failed for '{query}': {e}")
+        
+        logger.info(f"Found {len(tracks)} workout tracks based on user's genres: {user_genres}")
+        return tracks
+    
+    async def _get_spotify_recommendations(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+        """Use Spotify's powerful recommendations API to discover millions of tracks."""
+        tracks = []
+        
+        try:
+            # Spotify recommendations API parameters
+            seed_artists = [artist.id for artist in taste_profile['artist_infos'][:5]]  # Max 5 seed artists
+            seed_genres = taste_profile['genres'][:5]  # Max 5 seed genres
+            
+            # Audio feature targets for workout music
+            audio_features = {
+                'target_energy': 0.9,        # VERY high energy (aggressive)
+                'target_danceability': 0.4,  # Lower danceability (more rock/metal)
+                'target_valence': 0.5,       # Neutral/aggressive mood (not too happy)
+                'min_tempo': 130,             # Higher minimum BPM (aggressive)
+                'target_tempo': 160,          # Much higher target BPM (fast/aggressive)
+                'min_popularity': 50,         # Popular tracks but allow some variety
+                'target_popularity': 80       # Target popular tracks
+            }
+            
+            # Multiple recommendation calls for variety
+            for i in range(3):  # 3 batches of recommendations
+                try:
+                    # Vary the seed combinations for each batch
+                    batch_artists = seed_artists[i:i+3] if len(seed_artists) > i else seed_artists[:3]
+                    batch_genres = seed_genres[i:i+2] if len(seed_genres) > i else seed_genres[:2]
+                    
+                    # Slightly vary audio features for each batch
+                    varied_features = audio_features.copy()
+                    varied_features['target_energy'] += (i - 1) * 0.1  # 0.7, 0.8, 0.9
+                    varied_features['target_tempo'] += i * 10  # 130, 140, 150
+                    
+                    recommendations = await self.spotify.get_recommendations(
+                        seed_artists=batch_artists,
+                        seed_genres=batch_genres,
+                        limit=target_count // 2,  # Get plenty per batch
+                        **varied_features
+                    )
+                    
+                    tracks.extend(recommendations)
+                    logger.info(f"Batch {i+1}: Found {len(recommendations)} recommendations")
+                    
+                except Exception as e:
+                    logger.warning(f"Recommendation batch {i+1} failed: {e}")
+            
+            logger.info(f"Total recommendations found: {len(tracks)}")
+            
+        except Exception as e:
+            logger.warning(f"Spotify recommendations failed: {e}")
+        
+        return tracks
+    
+    async def _search_by_audio_features(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+        """Search tracks by combining genres with specific audio features."""
+        tracks = []
+        
+        # Audio feature combinations for different workout moods
+        feature_combinations = [
+            # High energy metal/rock
+            {'genre': 'metal', 'energy': '0.8..1.0', 'tempo': '120..180', 'danceability': '0.3..0.8'},
+            # Electronic workout
+            {'genre': 'electronic', 'energy': '0.7..1.0', 'tempo': '128..140', 'danceability': '0.6..1.0'},
+            # Hip hop workout
+            {'genre': 'hip hop', 'energy': '0.6..0.9', 'tempo': '80..120', 'danceability': '0.7..1.0'},
+            # Alternative/indie energy
+            {'genre': 'alternative', 'energy': '0.6..0.9', 'tempo': '100..160', 'valence': '0.4..0.8'},
+        ]
+        
+        for combo in feature_combinations:
+            try:
+                # Build advanced search query
+                query_parts = [f"genre:{combo['genre']}"]
+                
+                # Add audio feature filters
+                for feature, range_val in combo.items():
+                    if feature != 'genre':
+                        query_parts.append(f"{feature}:{range_val}")
+                
+                query = ' '.join(query_parts)
+                search_tracks = await self.spotify.search_tracks(query, limit=target_count // 4)
+                tracks.extend(search_tracks)
+                
+                logger.info(f"Audio feature search '{combo['genre']}': {len(search_tracks)} tracks")
+                
+            except Exception as e:
+                logger.warning(f"Audio feature search failed for {combo}: {e}")
+        
+        return tracks
+    
+    async def _search_similar_tracks(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+        """Search for tracks similar to user's favorites using track names and artists."""
+        tracks = []
+        
+        try:
+            # Get some reference track names for similarity searches
+            reference_tracks = taste_profile.get('sample_tracks', [])[:10]
+            
+            for ref_track in reference_tracks:
+                try:
+                    # Search variations of track/artist names
+                    artist_name = ref_track.get('artist', '').split(',')[0].strip()
+                    track_name = ref_track.get('name', '')
+                    
+                    # Search for similar artist styles
+                    if artist_name:
+                        query = f'artist:"{artist_name}" OR genre:"{artist_name.lower()}"'
+                        similar_tracks = await self.spotify.search_tracks(query, limit=5)
+                        tracks.extend(similar_tracks)
+                    
+                except Exception as e:
+                    logger.warning(f"Similar track search failed for {ref_track}: {e}")
+            
+            logger.info(f"Similar track searches found: {len(tracks)} tracks")
+            
+        except Exception as e:
+            logger.warning(f"Similar tracks search failed: {e}")
+        
+        return tracks
+    
+    async def _search_hidden_gems(self, taste_profile: Dict[str, Any], target_count: int) -> List[TrackInfo]:
+        """Search for less popular but quality tracks in user's genres."""
+        tracks = []
+        
+        for genre in taste_profile['genres'][:3]:
+            try:
+                # Search for tracks with lower popularity (hidden gems)
+                queries = [
+                    f'genre:"{genre}" year:2020..2024',  # Recent tracks
+                    f'genre:"{genre}" year:2015..2019',  # Slightly older
+                    f'genre:"{genre}" year:2010..2014',  # Classic period
+                ]
+                
+                for query in queries:
+                    hidden_tracks = await self.spotify.search_tracks(query, limit=target_count // 9)
+                    tracks.extend(hidden_tracks)
+                
+                logger.info(f"Hidden gems for {genre}: {len(tracks)} tracks found")
+                
+            except Exception as e:
+                logger.warning(f"Hidden gems search failed for {genre}: {e}")
+        
+        return tracks
+    
+    async def _filter_unknown_tracks(self, tracks: List[TrackInfo], known_track_ids: Set[str]) -> List[TrackInfo]:
+        """Filter out tracks that the user already knows."""
+        unknown_tracks = [track for track in tracks if track.id not in known_track_ids]
+        
+        logger.info(f"Filtered out {len(tracks) - len(unknown_tracks)} known tracks")
+        return unknown_tracks
+    
+    def _select_best_tracks(self, tracks: List[TrackInfo], target_count: int) -> List[TrackInfo]:
+        """Select the best tracks for the playlist."""
+        if len(tracks) <= target_count:
+            return tracks
+        
+        # Sort by popularity (higher is better) and randomize within popularity tiers
+        sorted_tracks = sorted(tracks, key=lambda t: (t.popularity or 0), reverse=True)
+        
+        # Take top tracks with some randomization
+        top_tier = sorted_tracks[:target_count * 2]  # Top tier candidates
+        selected = random.sample(top_tier, min(target_count, len(top_tier)))
+        
+        logger.info(f"Selected {len(selected)} best tracks from {len(tracks)} candidates")
+        return selected
+    
+    async def _create_discovery_playlist(self, tracks: List[TrackInfo], taste_profile: Dict[str, Any]) -> Dict[str, Any]:
+        """Create the discovery playlist."""
+        today = datetime.now()
+        playlist_name = f"Music Discovery - {today.strftime('%Y-%m-%d')}"
+        
+        description = (
+            f"Discovered {len(tracks)} new tracks based on your taste profile. "
+            f"Genres: {', '.join(taste_profile['genres'][:3])}. "
+            f"Generated on {today.strftime('%B %d, %Y')}."
+        )
+        
+        # Check if playlist exists
+        existing_playlist = await self.spotify.find_playlist_by_name(playlist_name)
+        if existing_playlist:
+            playlist_info = existing_playlist
+            logger.info(f"Found existing playlist: {playlist_name}")
+        else:
+            playlist_info = await self.spotify.create_playlist(playlist_name, description)
+            logger.info(f"Created new playlist: {playlist_name}")
+        
+        # Update playlist with tracks
+        track_uris = [track.uri for track in tracks]
+        await self.spotify.update_playlist_tracks(playlist_info.id, track_uris)
+        
+        return {
+            'playlist_id': playlist_info.id,
+            'playlist_name': playlist_info.name,
+            'playlist_url': playlist_info.external_url,
+            'tracks': tracks,
+            'taste_profile': {
+                'genres': taste_profile['genres'],
+                'artists_analyzed': taste_profile['artists_analyzed']
+            },
+            'discovery_methods': ['genre_search', 'related_artists', 'workout_genres'],
+            'stats': {
+                'total_discovered': len(tracks),
+                'avg_popularity': sum(track.popularity or 0 for track in tracks) / len(tracks) if tracks else 0
+            }
+        } 

--- a/services/spotify_service.py
+++ b/services/spotify_service.py
@@ -1,0 +1,380 @@
+"""Spotify service implementation using the modular interface."""
+
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+from typing import Dict, List, Any, Optional, Tuple
+from pathlib import Path
+
+from loguru import logger
+
+from base_music_service import BaseMusicService, MusicServiceType, TrackInfo, PlaylistInfo, ArtistInfo
+
+
+class SpotifyService(BaseMusicService):
+    """Spotify implementation of the music service interface."""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize Spotify service."""
+        super().__init__(config)
+        self.client: Optional[spotipy.Spotify] = None
+    
+    @property
+    def service_type(self) -> MusicServiceType:
+        """Get the service type."""
+        return MusicServiceType.SPOTIFY
+    
+    @property
+    def service_name(self) -> str:
+        """Get the human-readable service name."""
+        return "Spotify"
+    
+    def validate_config(self) -> Tuple[bool, List[str]]:
+        """Validate Spotify configuration."""
+        errors = []
+        
+        required_keys = [
+            'SPOTIFY_CLIENT_ID',
+            'SPOTIFY_CLIENT_SECRET',
+            'SPOTIFY_REDIRECT_URI',
+            'REFERENCE_PLAYLIST_ID'
+        ]
+        
+        for key in required_keys:
+            if not self.config.get(key):
+                errors.append(f"Missing required configuration: {key}")
+            elif self.config.get(key) in ['your_client_id_here', 'your_client_secret_here', 'your_playlist_id_here']:
+                errors.append(f"Please set a real value for {key}")
+        
+        # Validate redirect URI format
+        redirect_uri = self.config.get('SPOTIFY_REDIRECT_URI', '')
+        if redirect_uri and not (redirect_uri.startswith('http://') or redirect_uri.startswith('https://')):
+            errors.append("SPOTIFY_REDIRECT_URI must be a valid HTTP/HTTPS URL")
+        
+        return len(errors) == 0, errors
+    
+    async def authenticate(self) -> bool:
+        """Authenticate with Spotify."""
+        try:
+            # Setup cache directory
+            cache_dir = Path.home() / ".multi_music_generator" / "spotify"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            
+            # Set up OAuth with required scopes
+            scope = "playlist-modify-public playlist-modify-private playlist-read-private user-library-read"
+            
+            auth_manager = SpotifyOAuth(
+                client_id=self.config['SPOTIFY_CLIENT_ID'],
+                client_secret=self.config['SPOTIFY_CLIENT_SECRET'],
+                redirect_uri=self.config['SPOTIFY_REDIRECT_URI'],
+                scope=scope,
+                cache_path=str(cache_dir / ".spotify_cache")
+            )
+            
+            self.client = spotipy.Spotify(auth_manager=auth_manager)
+            
+            # Test authentication by getting current user
+            user = self.client.current_user()
+            if user:
+                self.authenticated = True
+                logger.info(f"Successfully authenticated with Spotify as: {user['display_name']} ({user['id']})")
+                return True
+            else:
+                return False
+                
+        except Exception as e:
+            logger.error(f"Failed to authenticate with Spotify: {e}")
+            return False
+    
+    async def get_current_user(self) -> Dict[str, Any]:
+        """Get current authenticated user information."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        user = self.client.current_user()
+        return {
+            'id': user['id'],
+            'name': user.get('display_name', 'Unknown'),
+            'followers': user.get('followers', {}).get('total', 0),
+            'country': user.get('country', 'Unknown'),
+            'external_url': user.get('external_urls', {}).get('spotify', '')
+        }
+    
+    async def get_playlist_tracks(self, playlist_id: str) -> List[TrackInfo]:
+        """Get all tracks from a Spotify playlist."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        tracks = []
+        results = self.client.playlist_tracks(playlist_id)
+        
+        while results:
+            for item in results['items']:
+                if item['track'] and item['track']['id']:
+                    track = item['track']
+                    
+                    # Get artist names
+                    artists = [artist['name'] for artist in track['artists']]
+                    
+                    track_info = TrackInfo(
+                        id=track['id'],
+                        name=track['name'],
+                        artist=', '.join(artists),
+                        album=track['album']['name'],
+                        uri=track['uri'],
+                        external_url=track['external_urls']['spotify'],
+                        duration_ms=track['duration_ms'],
+                        explicit=track['explicit'],
+                        popularity=track['popularity']
+                    )
+                    tracks.append(track_info)
+            
+            # Check if there are more pages
+            if results['next']:
+                results = self.client.next(results)
+            else:
+                results = None
+        
+        logger.info(f"Retrieved {len(tracks)} tracks from playlist {playlist_id}")
+        return tracks
+    
+    async def create_playlist(self, name: str, description: str = "", public: bool = True) -> PlaylistInfo:
+        """Create a new Spotify playlist."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        user = self.client.current_user()
+        playlist = self.client.user_playlist_create(
+            user=user['id'],
+            name=name,
+            public=public,
+            description=description
+        )
+        
+        playlist_info = PlaylistInfo(
+            id=playlist['id'],
+            name=playlist['name'],
+            description=playlist['description'],
+            track_count=playlist['tracks']['total'],
+            external_url=playlist['external_urls']['spotify'],
+            public=playlist['public']
+        )
+        
+        logger.info(f"Created playlist: {name} ({playlist['id']})")
+        return playlist_info
+    
+    async def update_playlist_tracks(self, playlist_id: str, track_uris: List[str]) -> bool:
+        """Update Spotify playlist with new tracks."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        try:
+            # Clear existing tracks
+            self.client.playlist_replace_items(playlist_id, [])
+            
+            # Add new tracks in batches (Spotify API limit is 100 per request)
+            batch_size = 100
+            for i in range(0, len(track_uris), batch_size):
+                batch = track_uris[i:i + batch_size]
+                self.client.playlist_add_items(playlist_id, batch)
+            
+            logger.info(f"Updated playlist {playlist_id} with {len(track_uris)} tracks")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to update playlist {playlist_id}: {e}")
+            return False
+    
+    async def find_playlist_by_name(self, name: str) -> Optional[PlaylistInfo]:
+        """Find a Spotify playlist by name."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        user = self.client.current_user()
+        playlists = self.client.user_playlists(user['id'])
+        
+        while playlists:
+            for playlist in playlists['items']:
+                if playlist['name'] == name:
+                    return PlaylistInfo(
+                        id=playlist['id'],
+                        name=playlist['name'],
+                        description=playlist['description'] or "",
+                        track_count=playlist['tracks']['total'],
+                        external_url=playlist['external_urls']['spotify'],
+                        public=playlist['public']
+                    )
+            
+            if playlists['next']:
+                playlists = self.client.next(playlists)
+            else:
+                playlists = None
+        
+        return None
+    
+    async def search_tracks(self, query: str, limit: int = 20) -> List[TrackInfo]:
+        """Search for tracks on Spotify."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        results = self.client.search(q=query, type='track', limit=limit, market='US')
+        tracks = []
+        
+        for track in results['tracks']['items']:
+            artists = [artist['name'] for artist in track['artists']]
+            
+            track_info = TrackInfo(
+                id=track['id'],
+                name=track['name'],
+                artist=', '.join(artists),
+                album=track['album']['name'],
+                uri=track['uri'],
+                external_url=track['external_urls']['spotify'],
+                duration_ms=track['duration_ms'],
+                explicit=track['explicit'],
+                popularity=track['popularity']
+            )
+            tracks.append(track_info)
+        
+        return tracks
+    
+    async def get_artist_info(self, artist_id: str) -> ArtistInfo:
+        """Get detailed Spotify artist information."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        artist = self.client.artist(artist_id)
+        
+        return ArtistInfo(
+            id=artist['id'],
+            name=artist['name'],
+            genres=artist['genres'],
+            popularity=artist['popularity'],
+            external_url=artist['external_urls']['spotify']
+        )
+    
+    async def get_related_artists(self, artist_id: str) -> List[ArtistInfo]:
+        """Get artists related to the given Spotify artist."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        results = self.client.artist_related_artists(artist_id)
+        artists = []
+        
+        for artist in results['artists']:
+            artist_info = ArtistInfo(
+                id=artist['id'],
+                name=artist['name'],
+                genres=artist['genres'],
+                popularity=artist['popularity'],
+                external_url=artist['external_urls']['spotify']
+            )
+            artists.append(artist_info)
+        
+        return artists
+    
+    async def get_artist_top_tracks(self, artist_id: str, limit: int = 10) -> List[TrackInfo]:
+        """Get top tracks for a Spotify artist."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        results = self.client.artist_top_tracks(artist_id, country='US')
+        tracks = []
+        
+        for track in results['tracks'][:limit]:
+            artists = [artist['name'] for artist in track['artists']]
+            
+            track_info = TrackInfo(
+                id=track['id'],
+                name=track['name'],
+                artist=', '.join(artists),
+                album=track['album']['name'],
+                uri=track['uri'],
+                external_url=track['external_urls']['spotify'],
+                duration_ms=track['duration_ms'],
+                explicit=track['explicit'],
+                popularity=track['popularity']
+            )
+            tracks.append(track_info)
+        
+        return tracks
+    
+    async def get_user_saved_tracks(self, limit: int = 50) -> List[TrackInfo]:
+        """Get user's saved/liked tracks from Spotify."""
+        if not self.authenticated or not self.client:
+            raise Exception("Not authenticated with Spotify")
+        
+        tracks = []
+        results = self.client.current_user_saved_tracks(limit=min(limit, 50))
+        
+        for item in results['items']:
+            track = item['track']
+            artists = [artist['name'] for artist in track['artists']]
+            
+            track_info = TrackInfo(
+                id=track['id'],
+                name=track['name'],
+                artist=', '.join(artists),
+                album=track['album']['name'],
+                uri=track['uri'],
+                external_url=track['external_urls']['spotify'],
+                duration_ms=track['duration_ms'],
+                explicit=track['explicit'],
+                popularity=track['popularity']
+            )
+            tracks.append(track_info)
+        
+        return tracks 
+    async def get_recommendations(self, seed_artists: List[str] = None, seed_genres: List[str] = None, 
+                                 seed_tracks: List[str] = None, limit: int = 20, **audio_features) -> List[TrackInfo]:
+        """Get track recommendations using Spotify's powerful recommendations API.
+        
+        This taps into Spotify's millions of tracks using machine learning.
+        
+        Args:
+            seed_artists: List of artist IDs to base recommendations on
+            seed_genres: List of genre names (e.g., ['metal', 'rock'])  
+            seed_tracks: List of track IDs to base recommendations on
+            limit: Number of recommendations to return (max 100)
+            **audio_features: Audio feature targets (e.g., target_energy=0.8, min_tempo=120)
+        """
+        try:
+            # Build parameters
+            params = {'limit': min(limit, 100)}  # Spotify max is 100
+            
+            # Add seed parameters (must have at least 1, max 5 total)
+            if seed_artists:
+                params['seed_artists'] = ','.join(seed_artists[:5])
+            if seed_genres:
+                params['seed_genres'] = ','.join(seed_genres[:5])  
+            if seed_tracks:
+                params['seed_tracks'] = ','.join(seed_tracks[:5])
+            
+            # Add audio feature parameters
+            for key, value in audio_features.items():
+                params[key] = value
+            
+            # Make API call
+            result = self.client.recommendations(**params)
+            
+            # Convert to TrackInfo objects
+            tracks = []
+            for track in result['tracks']:
+                track_info = TrackInfo(
+                    id=track['id'],
+                    name=track['name'],
+                    artist=', '.join([artist['name'] for artist in track['artists']]),
+                    album=track['album']['name'],
+                    uri=track['uri'],
+                    external_url=track['external_urls'].get('spotify', ''),
+                    duration_ms=track['duration_ms'],
+                    explicit=track['explicit'],
+                    popularity=track['popularity']
+                )
+                tracks.append(track_info)
+            
+            logger.info(f"Got {len(tracks)} recommendations from Spotify API")
+            return tracks
+            
+        except Exception as e:
+            logger.error(f"Failed to get recommendations: {e}")
+            return []

--- a/services/youtube_curator.py
+++ b/services/youtube_curator.py
@@ -1,0 +1,392 @@
+"""YouTube Music curator implementation."""
+
+import json
+import random
+from datetime import datetime, timedelta
+from typing import Dict, List, Any
+from pathlib import Path
+from collections import Counter
+
+from loguru import logger
+
+from base_music_service import BaseCurator, TrackInfo
+from services.youtube_service import YouTubeMusicService
+
+
+class YouTubeCurator(BaseCurator):
+    """YouTube Music-specific implementation of playlist curation."""
+    
+    def __init__(self, music_service: YouTubeMusicService):
+        """Initialize with YouTube Music service."""
+        super().__init__(music_service)
+        self.youtube = music_service
+        self.history_file = Path.cwd() / "youtube_usage_history.json"
+    
+    async def generate_curated_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Generate a curated playlist from existing YouTube Music tracks."""
+        try:
+            logger.info("Generating curated YouTube Music playlist with enhanced variety algorithms")
+            
+            # Get reference playlist tracks
+            reference_tracks = await self.youtube.get_playlist_tracks(reference_playlist_id)
+            logger.info(f"Reference playlist has {len(reference_tracks)} tracks")
+            
+            if not reference_tracks:
+                raise ValueError("Reference playlist is empty")
+            
+            # Load usage history
+            usage_history = self._load_usage_history()
+            
+            # Smart selection with variety optimization
+            selected_tracks = await self._smart_select_with_history(reference_tracks, usage_history, target_size, reference_playlist_id)
+            
+            logger.info(f"Selected {len(selected_tracks)} tracks with optimized variety")
+            
+            # Create playlist
+            today = datetime.now()
+            playlist_name = f"Curated Workout - {today.strftime('%Y-%m-%d')}"
+            
+            # Check if playlist already exists
+            existing_playlist = await self.youtube.find_playlist_by_name(playlist_name)
+            
+            if existing_playlist:
+                logger.info(f"Found existing playlist: {playlist_name}")
+                playlist_info = existing_playlist
+            else:
+                # Create new playlist
+                description = f"Smart curated playlist generated on {today.strftime('%B %d, %Y')}"
+                playlist_info = await self.youtube.create_playlist(playlist_name, description)
+                logger.info(f"Created new playlist: {playlist_name}")
+            
+            # Update playlist with selected tracks
+            track_uris = [track.uri for track in selected_tracks]
+            success, actual_track_count = await self.youtube.update_playlist_tracks(playlist_info.id, track_uris)
+            
+            if not success:
+                logger.warning("Failed to update playlist tracks")
+            
+            # Get selection stats for freshness score
+            selection_stats = self._get_selection_stats(selected_tracks, reference_tracks, usage_history)
+            
+            # Calculate freshness score - simpler approach
+            # Count tracks that haven't been used recently (last 7 days)
+            recent_cutoff = datetime.now() - timedelta(days=7)
+            recently_used = 0
+            
+            for track in selected_tracks[:actual_track_count]:
+                is_recently_used = False
+                for date_str, date_data in usage_history.items():
+                    try:
+                        date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+                        if date_obj >= recent_cutoff:
+                            if any(t.get('id') == track.id for t in date_data.get('tracks', [])):
+                                recently_used += 1
+                                is_recently_used = True
+                                break
+                    except (ValueError, KeyError):
+                        continue
+                    if is_recently_used:
+                        break
+            
+            freshness_score = round(((actual_track_count - recently_used) / actual_track_count) * 100, 1) if actual_track_count > 0 else 100.0
+            
+            # Update usage history AFTER calculating freshness
+            self._update_usage_history(selected_tracks, usage_history)
+            
+            return {
+                'playlist_id': playlist_info.id,
+                'playlist_name': playlist_info.name,
+                'playlist_url': playlist_info.external_url,
+                'tracks': selected_tracks[:actual_track_count] if success else selected_tracks,
+                'freshness_score': freshness_score,
+                'stats': {
+                    'total_added': actual_track_count,
+                    'unique_artists': selection_stats['unique_artists'],
+                    'recently_used': recently_used,
+                    'freshness_details': f"{actual_track_count - recently_used}/{actual_track_count} fresh tracks"
+                }
+            }
+            
+        except Exception as e:
+            logger.error(f"Curation failed: {e}")
+            raise Exception(f"Failed to generate curated YouTube Music playlist: {str(e)}")
+    
+    async def get_usage_stats(self) -> Dict[str, Any]:
+        """Get usage statistics for curation history."""
+        usage_history = self._load_usage_history()
+        
+        if not usage_history:
+            return {
+                'total_curations': 0,
+                'unique_tracks_used': 0,
+                'most_used_tracks': [],
+                'recent_activity': []
+            }
+        
+        # Calculate statistics
+        all_tracks = []
+        curation_dates = []
+        
+        for date, data in usage_history.items():
+            curation_dates.append(date)
+            all_tracks.extend(data.get('tracks', []))
+        
+        # Count track usage
+        track_counts = Counter()
+        for track in all_tracks:
+            track_key = f"{track.get('name', 'Unknown')} - {track.get('artist', 'Unknown')}"
+            track_counts[track_key] += 1
+        
+        return {
+            'total_curations': len(usage_history),
+            'unique_tracks_used': len(set(f"{t.get('name')}-{t.get('artist')}" for t in all_tracks)),
+            'most_used_tracks': [{'track': track, 'count': count} for track, count in track_counts.most_common(10)],
+            'recent_activity': sorted(curation_dates, reverse=True)[:10]
+        }
+    
+    async def _smart_select_with_history(self, tracks: List[TrackInfo], history: Dict, target_size: int, reference_playlist_id: str = None) -> List[TrackInfo]:
+        """Smart track selection considering usage history and variety."""
+        if len(tracks) <= target_size:
+            return tracks
+        
+        # Score each track based on history and variety factors
+        scored_tracks = []
+        
+        for track in tracks:
+            score = self._calculate_track_score(track, history)
+            scored_tracks.append((track, score))
+        
+        # Sort by score (higher is better)
+        scored_tracks.sort(key=lambda x: x[1], reverse=True)
+        
+        # Select tracks with artist diversity
+        selected_tracks = self._ensure_artist_diversity(scored_tracks, target_size)
+        
+        # Add some randomness to avoid predictability
+        if len(selected_tracks) >= target_size:
+            # Shuffle the bottom 30% to add variety
+            stable_count = int(len(selected_tracks) * 0.7)
+            stable_tracks = selected_tracks[:stable_count]
+            random_tracks = selected_tracks[stable_count:]
+            random.shuffle(random_tracks)
+            selected_tracks = stable_tracks + random_tracks
+        
+        # If we don't have enough tracks, discover new ones from the internet
+        if len(selected_tracks) < target_size and reference_playlist_id:
+            logger.info(f"🔍 Only found {len(selected_tracks)} tracks from reference. Discovering fresh tracks...")
+            
+            try:
+                from .youtube_discovery import YouTubeDiscoveryEngine
+                discovery_engine = YouTubeDiscoveryEngine(self.youtube)
+                
+                # Analyze the reference playlist to learn taste
+                logger.info("🔍 Analyzing your YouTube reference playlist...")
+                taste_profile = await discovery_engine.analyze_taste_profile(reference_playlist_id)
+                
+                logger.info(f"📊 Found artists: {', '.join(taste_profile['artists'][:5])}")
+                logger.info(f"🎤 Found {len(taste_profile['artists'])} artists to search")
+                
+                # Discover fresh tracks based on analyzed taste
+                needed = target_size - len(selected_tracks)
+                logger.info(f"🎵 Discovering {needed} fresh tracks based on YOUR taste...")
+                
+                # Get existing track IDs to avoid duplicates
+                existing_ids = {track.id for track in selected_tracks}
+                existing_ids.update(track.id for track in tracks)
+                
+                # Discover tracks
+                discovered = await discovery_engine.discover_tracks(reference_playlist_id, needed * 2)
+                fresh_tracks = discovered.get('tracks', [])
+                
+                # Filter out duplicates and slow tracks
+                slow_words = {'interview', 'interlude', 'ballad', 'acoustic', 'unplugged', 
+                             'slow', 'soft', 'quiet', 'gentle', 'mellow', 'calm', 'peaceful'}
+                
+                truly_fresh = []
+                for track in fresh_tracks:
+                    track_name_lower = track.name.lower()
+                    has_slow_words = any(word in track_name_lower for word in slow_words)
+                    
+                    if track.id not in existing_ids and not has_slow_words:
+                        truly_fresh.append(track)
+                        if len(truly_fresh) >= needed:
+                            break
+                
+                logger.info(f"✨ Found {len(truly_fresh)} fresh tracks from YouTube discovery")
+                selected_tracks.extend(truly_fresh)
+                
+            except Exception as e:
+                logger.error(f"Failed to discover fresh tracks: {e}")
+        
+        return selected_tracks[:target_size]
+    
+    def _calculate_track_score(self, track: TrackInfo, history: Dict) -> float:
+        """Calculate a score for track selection based on usage history."""
+        base_score = 100.0
+        
+        # Check usage history by BOTH ID and name/artist (YouTube IDs can be unreliable)
+        track_id = track.id
+        track_name_lower = track.name.lower().strip()
+        track_artist_lower = track.artist.lower().strip() if track.artist else ""
+        
+        usage_penalty = 0
+        recency_penalty = 0
+        times_used = 0
+        
+        # Calculate penalties based on recent usage
+        current_date = datetime.now()
+        
+        for date_str, data in history.items():
+            try:
+                usage_date = datetime.strptime(date_str, '%Y-%m-%d')
+                days_ago = (current_date - usage_date).days
+                
+                # Check if this track was used (by ID OR by name+artist match)
+                used_tracks = data.get('tracks', [])
+                track_used = False
+                
+                for used_track in used_tracks:
+                    # Check by ID
+                    if used_track.get('id') == track_id:
+                        track_used = True
+                        break
+                    # Also check by name+artist (case insensitive)
+                    used_name = used_track.get('name', '').lower().strip()
+                    used_artist = used_track.get('artist', '').lower().strip()
+                    if track_name_lower and used_name and track_name_lower == used_name:
+                        if track_artist_lower == used_artist or not track_artist_lower or not used_artist:
+                            track_used = True
+                            break
+                
+                if track_used:
+                    times_used += 1
+                    # MASSIVE penalties for ANY recent use
+                    if days_ago == 0:  # Used TODAY
+                        recency_penalty += 1000  # Essentially block it
+                    elif days_ago < 7:  # Used within a week
+                        recency_penalty += 500
+                    elif days_ago < 30:  # Used within a month
+                        recency_penalty += 100
+                    else:  # Used more than a month ago
+                        recency_penalty += 25
+                    
+                    usage_penalty += 50 * times_used  # Multiply penalty by usage count
+                    
+            except ValueError:
+                continue  # Skip invalid date entries
+        
+        # Apply penalties
+        final_score = base_score - usage_penalty - recency_penalty
+        
+        # Log if track was heavily penalized
+        if times_used > 0:
+            logger.debug(f"Track '{track.name}' used {times_used} times, score: {final_score} (penalties: usage={usage_penalty}, recency={recency_penalty})")
+        
+        # Add small random factor for variety
+        final_score += random.uniform(-5, 5)
+        
+        # Ensure minimum score
+        final_score = max(final_score, 1.0)
+        
+        return final_score
+    
+    def _ensure_artist_diversity(self, scored_tracks: List[tuple], target_size: int) -> List[TrackInfo]:
+        """Ensure artist diversity in the final selection."""
+        selected = []
+        artist_counts = Counter()
+        max_per_artist = max(1, target_size // 10)  # Limit tracks per artist
+        
+        # First pass: select high-scoring tracks with artist limits
+        for track, score in scored_tracks:
+            artist = track.artist if track.artist else 'Unknown'
+            
+            if artist_counts[artist] < max_per_artist:
+                selected.append(track)
+                artist_counts[artist] += 1
+                
+                if len(selected) >= target_size:
+                    break
+        
+        # Second pass: fill remaining slots if needed
+        if len(selected) < target_size:
+            remaining_tracks = [track for track, _ in scored_tracks if track not in selected]
+            random.shuffle(remaining_tracks)
+            
+            for track in remaining_tracks:
+                selected.append(track)
+                if len(selected) >= target_size:
+                    break
+        
+        return selected
+    
+    def _load_usage_history(self) -> Dict:
+        """Load usage history from file."""
+        try:
+            if self.history_file.exists():
+                with open(self.history_file, 'r') as f:
+                    return json.load(f)
+        except Exception as e:
+            logger.warning(f"Could not load usage history: {e}")
+        
+        return {}
+    
+    def _update_usage_history(self, selected_tracks: List[TrackInfo], history: Dict) -> None:
+        """Update usage history with selected tracks."""
+        try:
+            today = datetime.now().strftime('%Y-%m-%d')
+            
+            # Convert tracks to serializable format
+            track_data = []
+            for track in selected_tracks:
+                track_data.append({
+                    'id': track.id,
+                    'name': track.name,
+                    'artist': track.artist,
+                    'album': track.album,
+                    'uri': track.uri
+                })
+            
+            # Update history
+            history[today] = {
+                'tracks': track_data,
+                'track_count': len(selected_tracks),
+                'timestamp': datetime.now().isoformat()
+            }
+            
+            # Keep only last 60 days of history
+            sorted_dates = sorted(history.keys(), reverse=True)
+            if len(sorted_dates) > 60:
+                for old_date in sorted_dates[60:]:
+                    del history[old_date]
+            
+            # Save to file
+            with open(self.history_file, 'w') as f:
+                json.dump(history, f, indent=2)
+                
+            logger.info(f"Updated usage history for {today}")
+            
+        except Exception as e:
+            logger.error(f"Failed to update usage history: {e}")
+    
+    def _get_selection_stats(self, selected_tracks: List[TrackInfo], all_tracks: List[TrackInfo], history: Dict) -> Dict[str, Any]:
+        """Get statistics about the selection process."""
+        # Artist diversity
+        selected_artists = [track.artist for track in selected_tracks if track.artist]
+        artist_counts = Counter(selected_artists)
+        
+        # History stats
+        previously_used = 0
+        for track in selected_tracks:
+            for date_data in history.values():
+                if any(t.get('id') == track.id for t in date_data.get('tracks', [])):
+                    previously_used += 1
+                    break
+        
+        return {
+            'total_available': len(all_tracks),
+            'selected': len(selected_tracks),
+            'unique_artists': len(set(selected_artists)),
+            'artist_distribution': dict(artist_counts.most_common(10)),
+            'previously_used_count': previously_used,
+            'freshness_ratio': round((len(selected_tracks) - previously_used) / len(selected_tracks) * 100, 1) if selected_tracks else 0
+        } 

--- a/services/youtube_discovery.py
+++ b/services/youtube_discovery.py
@@ -1,0 +1,315 @@
+"""YouTube Music discovery engine implementation."""
+
+import random
+from typing import Dict, List, Any, Set
+from collections import Counter
+
+from loguru import logger
+
+from base_music_service import BaseDiscoveryEngine, TrackInfo
+from services.youtube_service import YouTubeMusicService
+
+
+class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
+    """YouTube Music-specific implementation of music discovery."""
+    
+    def __init__(self, music_service: YouTubeMusicService):
+        """Initialize with YouTube Music service."""
+        super().__init__(music_service)
+        self.youtube = music_service
+        
+        # YouTube Music workout-related search terms
+        self.workout_genres = [
+            "workout", "gym", "fitness", "cardio", "running", "training",
+            "exercise", "motivation", "pump up", "energy", "beast mode"
+        ]
+    
+    async def discover_new_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Discover new tracks for YouTube Music playlist based on user's taste."""
+        try:
+            logger.info("Starting YouTube Music discovery process")
+            
+            # Analyze user's taste from reference playlist
+            taste_profile = await self.analyze_taste_profile(reference_playlist_id)
+            logger.info(f"Analyzed taste profile: {len(taste_profile['artists'])} artists, {len(taste_profile['genres'])} genres")
+            
+            # Get user's existing tracks to avoid duplicates
+            existing_tracks = await self._get_user_tracks()
+            existing_video_ids = {track.id for track in existing_tracks}
+            logger.info(f"Found {len(existing_video_ids)} existing tracks to avoid")
+            
+            # Discover new tracks using multiple strategies
+            discovered_tracks = []
+            
+            # Strategy 1: Search by workout terms (40%)
+            workout_target = max(1, int(target_size * 0.4))
+            workout_tracks = await self._search_workout_content(workout_target, existing_video_ids, taste_profile)
+            discovered_tracks.extend(workout_tracks)
+            
+            # Strategy 2: Search by user's favorite terms (40%)
+            if taste_profile['artists']:
+                artist_target = max(1, int(target_size * 0.4))
+                artist_tracks = await self._search_by_artists(taste_profile['artists'][:10], artist_target, existing_video_ids)
+                discovered_tracks.extend(artist_tracks)
+            
+            # Strategy 3: Diverse music search (20%)
+            diverse_target = max(1, target_size - len(discovered_tracks))
+            if diverse_target > 0:
+                diverse_tracks = await self._search_diverse_music(diverse_target, existing_video_ids)
+                discovered_tracks.extend(diverse_tracks)
+            
+            # Remove duplicates and limit to target size
+            unique_tracks = self._deduplicate_tracks(discovered_tracks)
+            final_tracks = unique_tracks[:target_size]
+            
+            logger.info(f"Discovered {len(final_tracks)} new tracks")
+            
+            # Create playlist
+            playlist_info = await self._create_discovery_playlist(final_tracks)
+            
+            return {
+                'playlist': playlist_info,
+                'tracks': final_tracks,
+                'taste_profile': taste_profile,
+                'strategies_used': ['workout_search', 'artist_search', 'diverse_search']
+            }
+            
+        except Exception as e:
+            logger.error(f"Discovery failed: {e}")
+            raise Exception(f"Failed to discover YouTube Music tracks: {str(e)}")
+    
+    async def analyze_taste_profile(self, reference_playlist_id: str) -> Dict[str, Any]:
+        """Analyze user's music taste from reference playlist."""
+        try:
+            # Get reference playlist tracks
+            reference_tracks = await self.youtube.get_playlist_tracks(reference_playlist_id)
+            logger.info(f"Analyzing {len(reference_tracks)} reference tracks")
+            
+            if not reference_tracks:
+                logger.warning("No reference tracks found")
+                return {'artists': [], 'genres': [], 'track_count': 0}
+            
+            # Extract artists
+            artists = []
+            for track in reference_tracks:
+                if track.artist and track.artist != 'Unknown Artist':
+                    # Split comma-separated artists
+                    track_artists = [a.strip() for a in track.artist.split(',') if a.strip()]
+                    artists.extend(track_artists)
+            
+            # Count artist frequency
+            artist_counts = Counter(artists)
+            top_artists = [artist for artist, count in artist_counts.most_common(20)]
+            
+            # YouTube Music doesn't provide detailed genre info, so we'll derive it from search
+            genres = await self._derive_genres_from_artists(top_artists[:5])
+            
+            taste_profile = {
+                'artists': top_artists,
+                'genres': genres,
+                'track_count': len(reference_tracks),
+                'top_artist_counts': dict(artist_counts.most_common(10))
+            }
+            
+            logger.info(f"Taste profile: {len(top_artists)} artists, {len(genres)} derived genres")
+            return taste_profile
+            
+        except Exception as e:
+            logger.error(f"Failed to analyze taste profile: {e}")
+            return {'artists': [], 'genres': [], 'track_count': 0}
+    
+    async def _derive_genres_from_artists(self, artists: List[str]) -> List[str]:
+        """Derive genre-like terms from top artists by searching related content."""
+        genres = set()
+        
+        for artist in artists[:3]:  # Limit to avoid too many API calls
+            try:
+                # Search for the artist to get related content
+                search_results = await self.youtube.search_tracks(f"{artist} music", limit=5)
+                
+                # Extract genre-like keywords from titles and artists
+                for track in search_results:
+                    title_words = track.name.lower().split()
+                    for word in title_words:
+                        # Look for genre-like words
+                        if word in ['rock', 'pop', 'metal', 'rap', 'hip', 'hop', 'electronic', 
+                                  'dance', 'acoustic', 'folk', 'country', 'jazz', 'blues',
+                                  'reggae', 'punk', 'alternative', 'indie', 'classical']:
+                            genres.add(word)
+                
+            except Exception as e:
+                logger.warning(f"Could not derive genres for artist {artist}: {e}")
+                continue
+        
+        return list(genres)
+    
+    async def _search_workout_content(self, target_count: int, existing_ids: Set[str], taste_profile: Dict[str, Any] = None) -> List[TrackInfo]:
+        """Search for workout-related music content based on user's taste."""
+        tracks = []
+        
+        # Use genres from taste profile if available, otherwise use defaults
+        if taste_profile and taste_profile.get('genres'):
+            search_terms = []
+            for genre in taste_profile['genres'][:3]:
+                # Add workout modifiers to user's genres
+                search_terms.extend([
+                    f"{genre} workout high energy",
+                    f"{genre} aggressive intense"
+                ])
+        else:
+            search_terms = [f"{term} music" for term in self.workout_genres[:5]]
+        
+        for term in search_terms[:5]:  # Limit searches
+            try:
+                search_limit = max(1, target_count // max(1, len(search_terms[:5])))
+                search_results = await self.youtube.search_tracks(term, limit=search_limit)
+                
+                for track in search_results:
+                    if track.id not in existing_ids and track not in tracks:
+                        tracks.append(track)
+                        if len(tracks) >= target_count:
+                            break
+                
+                if len(tracks) >= target_count:
+                    break
+                    
+            except Exception as e:
+                logger.warning(f"Workout search failed for '{term}': {e}")
+                continue
+        
+        logger.info(f"Found {len(tracks)} workout tracks")
+        return tracks
+    
+    async def _search_by_artists(self, artists: List[str], target_count: int, existing_ids: Set[str]) -> List[TrackInfo]:
+        """Search for tracks by user's favorite artists and similar artists."""
+        tracks = []
+        
+        for artist in artists[:8]:  # Limit to avoid too many API calls
+            try:
+                search_limit = max(1, target_count // max(1, len(artists[:8])))
+                
+                # Search for tracks by this artist
+                search_results = await self.youtube.search_tracks(f"{artist} songs", limit=search_limit)
+                
+                for track in search_results:
+                    if track.id not in existing_ids and track not in tracks:
+                        tracks.append(track)
+                        if len(tracks) >= target_count:
+                            break
+                
+                if len(tracks) >= target_count:
+                    break
+                    
+            except Exception as e:
+                logger.warning(f"Artist search failed for '{artist}': {e}")
+                continue
+        
+        logger.info(f"Found {len(tracks)} artist-based tracks")
+        return tracks
+    
+    async def _search_diverse_music(self, target_count: int, existing_ids: Set[str]) -> List[TrackInfo]:
+        """Search for diverse music to fill remaining slots."""
+        tracks = []
+        
+        diverse_terms = [
+            "new music 2024", "trending songs", "popular music", "top hits",
+            "fresh tracks", "latest releases", "viral songs"
+        ]
+        
+        for term in diverse_terms[:3]:  # Limit searches
+            try:
+                search_limit = max(1, target_count // max(1, len(diverse_terms[:3])))
+                search_results = await self.youtube.search_tracks(term, limit=search_limit)
+                
+                for track in search_results:
+                    if track.id not in existing_ids and track not in tracks:
+                        tracks.append(track)
+                        if len(tracks) >= target_count:
+                            break
+                
+                if len(tracks) >= target_count:
+                    break
+                    
+            except Exception as e:
+                logger.warning(f"Diverse search failed for '{term}': {e}")
+                continue
+        
+        logger.info(f"Found {len(tracks)} diverse tracks")
+        return tracks
+    
+    async def _get_user_tracks(self) -> List[TrackInfo]:
+        """Get user's existing tracks to avoid duplicates."""
+        try:
+            # Get liked songs
+            liked_tracks = await self.youtube.get_user_saved_tracks(limit=200)
+            return liked_tracks
+        except Exception as e:
+            logger.warning(f"Could not get user tracks: {e}")
+            return []
+    
+    def _deduplicate_tracks(self, tracks: List[TrackInfo]) -> List[TrackInfo]:
+        """Remove duplicate tracks based on ID and similar names."""
+        seen_ids = set()
+        seen_names = set()
+        unique_tracks = []
+        
+        for track in tracks:
+            # Check ID
+            if track.id in seen_ids:
+                continue
+            
+            # Check similar names (normalize for comparison)
+            normalized_name = track.name.lower().strip()
+            if normalized_name in seen_names:
+                continue
+            
+            seen_ids.add(track.id)
+            seen_names.add(normalized_name)
+            unique_tracks.append(track)
+        
+        return unique_tracks
+    
+    async def _create_discovery_playlist(self, tracks: List[TrackInfo]) -> Dict[str, Any]:
+        """Create a new discovery playlist with the found tracks."""
+        from datetime import datetime
+        
+        # Create playlist name with date
+        today = datetime.now()
+        playlist_name = f"Music Discovery - {today.strftime('%Y-%m-%d')}"
+        
+        try:
+            # Check if playlist already exists
+            existing_playlist = await self.youtube.find_playlist_by_name(playlist_name)
+            
+            if existing_playlist:
+                logger.info(f"Found existing playlist: {playlist_name}")
+                playlist_info = existing_playlist
+            else:
+                # Create new playlist
+                description = f"Daily music discovery playlist generated on {today.strftime('%B %d, %Y')}"
+                playlist_info = await self.youtube.create_playlist(playlist_name, description)
+                logger.info(f"Created new playlist: {playlist_name}")
+            
+            # Update playlist with tracks
+            track_uris = [track.uri for track in tracks]
+            success, actual_count = await self.youtube.update_playlist_tracks(playlist_info.id, track_uris)
+            
+            if success:
+                playlist_info.track_count = actual_count
+                logger.info(f"Updated playlist {playlist_info.id} with {actual_count} tracks")
+            else:
+                logger.warning("Failed to update playlist tracks")
+            
+            return {
+                'playlist_id': playlist_info.id,
+                'playlist_name': playlist_info.name,
+                'playlist_url': playlist_info.external_url,
+                'tracks': tracks[:actual_count] if success else tracks,
+                'stats': {
+                    'total_discovered': actual_count if success else len(tracks)
+                }
+            }
+            
+        except Exception as e:
+            logger.error(f"Failed to create/update playlist: {e}")
+            raise Exception(f"Could not create discovery playlist: {str(e)}") 

--- a/services/youtube_discovery.py
+++ b/services/youtube_discovery.py
@@ -23,60 +23,107 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
             "workout", "gym", "fitness", "cardio", "running", "training",
             "exercise", "motivation", "pump up", "energy", "beast mode"
         ]
+        # Lightweight stopwords for token extraction (formatting words, non-genre)
+        self._stopwords = {
+            'official', 'audio', 'video', 'music', 'feat', 'ft', 'and', 'with', 'the', 'a', 'an',
+            'remix', 'mix', 'hd', '4k', 'live', 'lyrics', 'edit', 'version', 'new', 'song', 'track',
+            'vol', 'volume', 'best', 'epic', 'workout', 'gym', 'running', 'fitness'
+        }
     
     async def discover_new_playlist(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
         """Discover new tracks for YouTube Music playlist based on user's taste."""
         try:
             logger.info("Starting YouTube Music discovery process")
-            
-            # Analyze user's taste from reference playlist
-            taste_profile = await self.analyze_taste_profile(reference_playlist_id)
-            logger.info(f"Analyzed taste profile: {len(taste_profile['artists'])} artists, {len(taste_profile['genres'])} genres")
-            
-            # Get user's existing tracks to avoid duplicates
-            existing_tracks = await self._get_user_tracks()
-            existing_video_ids = {track.id for track in existing_tracks}
-            logger.info(f"Found {len(existing_video_ids)} existing tracks to avoid")
-            
-            # Discover new tracks using multiple strategies
-            discovered_tracks = []
-            
-            # Strategy 1: Search by workout terms (40%)
-            workout_target = max(1, int(target_size * 0.4))
-            workout_tracks = await self._search_workout_content(workout_target, existing_video_ids, taste_profile)
-            discovered_tracks.extend(workout_tracks)
-            
-            # Strategy 2: Search by user's favorite terms (40%)
-            if taste_profile['artists']:
-                artist_target = max(1, int(target_size * 0.4))
-                artist_tracks = await self._search_by_artists(taste_profile['artists'][:10], artist_target, existing_video_ids)
-                discovered_tracks.extend(artist_tracks)
-            
-            # Strategy 3: Diverse music search (20%)
-            diverse_target = max(1, target_size - len(discovered_tracks))
-            if diverse_target > 0:
-                diverse_tracks = await self._search_diverse_music(diverse_target, existing_video_ids)
-                discovered_tracks.extend(diverse_tracks)
-            
-            # Remove duplicates and limit to target size
-            unique_tracks = self._deduplicate_tracks(discovered_tracks)
-            final_tracks = unique_tracks[:target_size]
-            
-            logger.info(f"Discovered {len(final_tracks)} new tracks")
-            
-            # Create playlist
-            playlist_info = await self._create_discovery_playlist(final_tracks)
-            
-            return {
-                'playlist': playlist_info,
-                'tracks': final_tracks,
-                'taste_profile': taste_profile,
-                'strategies_used': ['workout_search', 'artist_search', 'diverse_search']
-            }
+
+            # Reuse the track discovery routine
+            discovery = await self.discover_tracks(reference_playlist_id, target_size)
+            final_tracks = discovery.get('tracks', [])
+
+            # Create playlist using discovered tracks
+            playlist_payload = await self._create_discovery_playlist(final_tracks)
+
+            # Flatten shape to match Spotify's return for CLI compatibility
+            playlist_payload['taste_profile'] = discovery.get('taste_profile', {})
+            playlist_payload['strategies_used'] = discovery.get('strategies_used', [])
+            return playlist_payload
             
         except Exception as e:
             logger.error(f"Discovery failed: {e}")
             raise Exception(f"Failed to discover YouTube Music tracks: {str(e)}")
+
+    async def discover_tracks(self, reference_playlist_id: str, target_size: int = 30) -> Dict[str, Any]:
+        """Discover tracks only (without creating a playlist), used by curator fallback.
+
+        Returns a dict with keys: 'tracks', 'taste_profile', 'strategies_used'.
+        """
+        # Analyze user's taste from reference playlist
+        taste_profile = await self.analyze_taste_profile(reference_playlist_id)
+        logger.info(f"Analyzed taste profile: {len(taste_profile['artists'])} artists, {len(taste_profile['genres'])} genres")
+
+        # Get user's existing tracks to avoid duplicates
+        existing_tracks = await self._get_user_tracks()
+        existing_video_ids = {track.id for track in existing_tracks}
+        logger.info(f"Found {len(existing_video_ids)} existing tracks to avoid")
+
+        # Discover new tracks using multiple strategies
+        discovered_tracks: List[TrackInfo] = []
+
+        # Strategy 1: Search by workout terms (40%)
+        workout_target = max(1, int(target_size * 0.4))
+        workout_tracks = await self._search_workout_content(workout_target, existing_video_ids, taste_profile)
+        discovered_tracks.extend(workout_tracks)
+
+        # Strategy 2: Search by user's favorite terms (40%)
+        if taste_profile['artists']:
+            artist_target = max(1, int(target_size * 0.4))
+            artist_tracks = await self._search_by_artists(taste_profile['artists'][:10], artist_target, existing_video_ids)
+            discovered_tracks.extend(artist_tracks)
+
+        # Strategy 3: Recent music search (fresh-first, 20%)
+        diverse_target = max(1, target_size - len(discovered_tracks))
+        if diverse_target > 0:
+            recent_tracks = await self._search_recent_music(diverse_target, existing_video_ids, taste_profile)
+            discovered_tracks.extend(recent_tracks)
+
+        # Remove duplicates
+        unique_tracks = self._deduplicate_tracks(discovered_tracks)
+
+        # Enforce freshness: filter out any tracks from reference playlist and usage history
+        usage_used_ids = self._load_used_track_ids()
+        reference_ids = set(taste_profile.get('known_track_ids', set()))
+        reference_names = set(taste_profile.get('reference_track_names', set()))
+        slow_words = {'interview', 'interlude', 'ballad', 'acoustic', 'unplugged', 
+                      'slow', 'soft', 'quiet', 'gentle', 'mellow', 'calm', 'peaceful'}
+
+        filtered_tracks = []
+        # Adaptive blocklist: only exclude tokens not present in user's taste tokens (derived from reference)
+        edm_like = {'edm', 'trap', 'dubstep', 'electro', 'dance', 'remix', 'mix'}
+        allowed_tokens = set((g or '').lower() for g in (taste_profile.get('genres') or [])) | set(
+            (t or '').lower() for t in taste_profile.get('taste_tokens', [])
+        )
+        for tr in unique_tracks:
+            name_l = tr.name.lower().strip() if tr.name else ''
+            if tr.id in reference_ids:
+                continue
+            if name_l in reference_names:
+                continue
+            if tr.id in usage_used_ids:
+                continue
+            if any(w in name_l for w in slow_words):
+                continue
+            if any(w in name_l for w in edm_like) and not any(term in allowed_tokens for term in edm_like):
+                continue
+            filtered_tracks.append(tr)
+
+        final_tracks = filtered_tracks[:target_size]
+
+        logger.info(f"Discovered {len(final_tracks)} new tracks")
+
+        return {
+            'tracks': final_tracks,
+            'taste_profile': taste_profile,
+            'strategies_used': ['workout_search', 'artist_search', 'diverse_search']
+        }
     
     async def analyze_taste_profile(self, reference_playlist_id: str) -> Dict[str, Any]:
         """Analyze user's music taste from reference playlist."""
@@ -87,7 +134,13 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
             
             if not reference_tracks:
                 logger.warning("No reference tracks found")
-                return {'artists': [], 'genres': [], 'track_count': 0}
+                return {
+                    'artists': [],
+                    'genres': [],
+                    'track_count': 0,
+                    'known_track_ids': set(),
+                    'reference_track_names': set()
+                }
             
             # Extract artists
             artists = []
@@ -103,12 +156,45 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
             
             # YouTube Music doesn't provide detailed genre info, so we'll derive it from search
             genres = await self._derive_genres_from_artists(top_artists[:5])
+
+            # Also parse reference titles for genre-like hints (e.g., metal/rock) to guide searches
+            title_genres = set()
+            keyword_map = {
+                'metal': 'metal',
+                'rock': 'rock',
+                'hardcore': 'hardcore',
+                'grunge': 'grunge',
+                'nu': 'nu metal',
+                'post-grunge': 'post-grunge',
+                'industrial': 'industrial',
+                'hip hop': 'hip hop',
+                'rap metal': 'rap metal',
+                'alt': 'alternative',
+                'alternative': 'alternative',
+            }
+            for t in reference_tracks:
+                name_l = (t.name or '').lower()
+                if 'hip hop' in name_l:
+                    title_genres.add('hip hop')
+                for kw, g in keyword_map.items():
+                    if kw in name_l:
+                        title_genres.add(g)
+            if title_genres:
+                genres = list(set(genres) | title_genres)
             
+            # Build token-based taste profile from titles and artists
+            taste_tokens = set()
+            for t in reference_tracks:
+                taste_tokens |= self._extract_tokens((t.name or '') + ' ' + (t.artist or ''))
+
             taste_profile = {
                 'artists': top_artists,
                 'genres': genres,
                 'track_count': len(reference_tracks),
-                'top_artist_counts': dict(artist_counts.most_common(10))
+                'top_artist_counts': dict(artist_counts.most_common(10)),
+                'known_track_ids': {t.id for t in reference_tracks},
+                'reference_track_names': {t.name.lower().strip() for t in reference_tracks if t.name},
+                'taste_tokens': list(taste_tokens)
             }
             
             logger.info(f"Taste profile: {len(top_artists)} artists, {len(genres)} derived genres")
@@ -116,7 +202,7 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
             
         except Exception as e:
             logger.error(f"Failed to analyze taste profile: {e}")
-            return {'artists': [], 'genres': [], 'track_count': 0}
+            return {'artists': [], 'genres': [], 'track_count': 0, 'known_track_ids': set(), 'reference_track_names': set(), 'taste_tokens': []}
     
     async def _derive_genres_from_artists(self, artists: List[str]) -> List[str]:
         """Derive genre-like terms from top artists by searching related content."""
@@ -141,7 +227,23 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
                 logger.warning(f"Could not derive genres for artist {artist}: {e}")
                 continue
         
+        # Normalize combined genres (e.g., hip hop)
+        if 'hip' in genres and 'hop' in genres:
+            genres.discard('hip')
+            genres.discard('hop')
+            genres.add('hip hop')
+
         return list(genres)
+
+    def _extract_tokens(self, text: str) -> Set[str]:
+        """Extract normalized tokens from text, excluding stopwords. Used to adapt filters to the reference playlist."""
+        tokens: Set[str] = set()
+        for raw in text.lower().replace('|', ' ').replace('-', ' ').split():
+            t = raw.strip()
+            if not t or t in self._stopwords or len(t) <= 2:
+                continue
+            tokens.add(t)
+        return tokens
     
     async def _search_workout_content(self, target_count: int, existing_ids: Set[str], taste_profile: Dict[str, Any] = None) -> List[TrackInfo]:
         """Search for workout-related music content based on user's taste."""
@@ -187,10 +289,20 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
         for artist in artists[:8]:  # Limit to avoid too many API calls
             try:
                 search_limit = max(1, target_count // max(1, len(artists[:8])))
-                
-                # Search for tracks by this artist
-                search_results = await self.youtube.search_tracks(f"{artist} songs", limit=search_limit)
-                
+
+                # Prefer newer content: try multiple queries per artist
+                queries = [
+                    f"{artist} latest official audio",
+                    f"{artist} new 2024",
+                    f"{artist} new 2025",
+                    f"{artist} songs"
+                ]
+
+                search_results: List[TrackInfo] = []
+                for q in queries:
+                    results = await self.youtube.search_tracks(q, limit=search_limit)
+                    search_results.extend(results)
+
                 for track in search_results:
                     if track.id not in existing_ids and track not in tracks:
                         tracks.append(track)
@@ -207,34 +319,40 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
         logger.info(f"Found {len(tracks)} artist-based tracks")
         return tracks
     
-    async def _search_diverse_music(self, target_count: int, existing_ids: Set[str]) -> List[TrackInfo]:
-        """Search for diverse music to fill remaining slots."""
-        tracks = []
-        
-        diverse_terms = [
-            "new music 2024", "trending songs", "popular music", "top hits",
-            "fresh tracks", "latest releases", "viral songs"
-        ]
-        
-        for term in diverse_terms[:3]:  # Limit searches
+    async def _search_recent_music(self, target_count: int, existing_ids: Set[str], taste_profile: Dict[str, Any]) -> List[TrackInfo]:
+        """Search for recent music uploads using YouTube Data API with publishedAfter filter."""
+        tracks: List[TrackInfo] = []
+        queries: List[str] = []
+
+        # Bias queries with artists and derived genres from reference
+        for artist in (taste_profile.get('artists') or [])[:5]:
+            queries.append(f"{artist} official audio")
+            queries.append(f"{artist} new song")
+
+        for genre in (taste_profile.get('genres') or [])[:3]:
+            queries.append(f"{genre} new music")
+
+        # Generic if none available
+        if not queries:
+            queries = ["new music", "latest release"]
+
+        per_query = max(1, target_count // max(1, len(queries)))
+        for q in queries:
             try:
-                search_limit = max(1, target_count // max(1, len(diverse_terms[:3])))
-                search_results = await self.youtube.search_tracks(term, limit=search_limit)
-                
-                for track in search_results:
-                    if track.id not in existing_ids and track not in tracks:
-                        tracks.append(track)
+                # Use last 30 days for maximum freshness
+                results = await self.youtube.search_recent_music(q, limit=per_query, days=30)
+                for tr in results:
+                    if tr.id not in existing_ids and tr not in tracks:
+                        tracks.append(tr)
                         if len(tracks) >= target_count:
                             break
-                
                 if len(tracks) >= target_count:
                     break
-                    
             except Exception as e:
-                logger.warning(f"Diverse search failed for '{term}': {e}")
+                logger.warning(f"Recent search failed for '{q}': {e}")
                 continue
-        
-        logger.info(f"Found {len(tracks)} diverse tracks")
+
+        logger.info(f"Found {len(tracks)} recent tracks")
         return tracks
     
     async def _get_user_tracks(self) -> List[TrackInfo]:
@@ -268,6 +386,25 @@ class YouTubeDiscoveryEngine(BaseDiscoveryEngine):
             unique_tracks.append(track)
         
         return unique_tracks
+
+    def _load_used_track_ids(self) -> Set[str]:
+        """Load previously used track IDs from youtube_usage_history.json for freshness filtering."""
+        from pathlib import Path
+        import json
+        used: Set[str] = set()
+        history_path = Path.cwd() / "youtube_usage_history.json"
+        try:
+            if history_path.exists():
+                with open(history_path, 'r') as f:
+                    data = json.load(f)
+                for day in data.values():
+                    for t in day.get('tracks', []):
+                        tid = t.get('id')
+                        if tid:
+                            used.add(tid)
+        except Exception as e:
+            logger.warning(f"Could not read usage history for freshness: {e}")
+        return used
     
     async def _create_discovery_playlist(self, tracks: List[TrackInfo]) -> Dict[str, Any]:
         """Create a new discovery playlist with the found tracks."""

--- a/services/youtube_service.py
+++ b/services/youtube_service.py
@@ -1,0 +1,554 @@
+"""YouTube Music service implementation."""
+
+import os
+import json
+from typing import Dict, List, Any, Optional, Tuple
+from pathlib import Path
+
+from ytmusicapi import YTMusic
+from google.auth.transport.requests import Request
+from google_auth_oauthlib.flow import Flow
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+import googleapiclient.errors
+from loguru import logger
+
+from base_music_service import BaseMusicService, MusicServiceType, TrackInfo, PlaylistInfo, ArtistInfo
+
+
+class YouTubeMusicService(BaseMusicService):
+    """YouTube Music implementation of the music service interface."""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize YouTube Music service."""
+        super().__init__(config)
+        self.ytmusic: Optional[YTMusic] = None
+        self.youtube_api = None  # YouTube Data API v3 client
+        self.credentials: Optional[Credentials] = None
+        self.token_file = Path.cwd() / "youtube_token.json"
+    
+    @property
+    def service_type(self) -> MusicServiceType:
+        """Get the service type."""
+        return MusicServiceType.YOUTUBE_MUSIC
+    
+    @property
+    def service_name(self) -> str:
+        """Get the human-readable service name."""
+        return "YouTube Music"
+    
+    def validate_config(self) -> Tuple[bool, List[str]]:
+        """Validate YouTube Music configuration."""
+        errors = []
+        
+        required_keys = [
+            'YOUTUBE_CLIENT_ID',
+            'YOUTUBE_CLIENT_SECRET',
+            'YOUTUBE_REDIRECT_URI',
+            'REFERENCE_PLAYLIST_ID'
+        ]
+        
+        for key in required_keys:
+            if not self.config.get(key):
+                errors.append(f"Missing required configuration: {key}")
+            elif self.config.get(key) in ['your_client_id_here', 'your_client_secret_here', 'your_playlist_id_here']:
+                errors.append(f"Please set a real value for {key}")
+        
+        # Validate redirect URI format
+        redirect_uri = self.config.get('YOUTUBE_REDIRECT_URI', '')
+        if redirect_uri and not (redirect_uri.startswith('http://') or redirect_uri.startswith('https://')):
+            errors.append("YOUTUBE_REDIRECT_URI must be a valid HTTP/HTTPS URL")
+        
+        return len(errors) == 0, errors
+    
+    async def authenticate(self) -> bool:
+        """Authenticate with YouTube Music."""
+        try:
+            # Allow HTTP for localhost development
+            import os
+            os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+            # Check if we have saved credentials
+            if self.token_file.exists():
+                logger.info("Loading saved YouTube Music credentials")
+                with open(self.token_file, 'r') as f:
+                    token_data = json.load(f)
+                
+                self.credentials = Credentials.from_authorized_user_info(token_data)
+                
+                # Refresh if expired
+                if self.credentials.expired and self.credentials.refresh_token:
+                    logger.info("Refreshing YouTube Music credentials")
+                    self.credentials.refresh(Request())
+                    self._save_credentials()
+            
+            # If no valid credentials, start OAuth flow
+            if not self.credentials or not self.credentials.valid:
+                logger.info("Starting YouTube Music OAuth flow")
+                await self._oauth_flow()
+            
+            # Initialize both YTMusic and YouTube Data API
+            if self.credentials and self.credentials.valid:
+                try:
+                    # Initialize YouTube Data API v3 with OAuth credentials
+                    self.youtube_api = build('youtube', 'v3', credentials=self.credentials)
+                    
+                    # Initialize YTMusic for public data (search, etc.)
+                    # Note: YTMusic requires browser auth for full functionality
+                    self.ytmusic = YTMusic()
+                    
+                    self.authenticated = True
+                    logger.info("Successfully authenticated with YouTube Music")
+                    return True
+                except Exception as e:
+                    logger.warning(f"YouTube API initialization failed: {e}")
+                    # Fall back to basic functionality
+                    try:
+                        self.ytmusic = YTMusic()
+                        self.authenticated = True
+                        logger.info("YouTube Music initialized with limited functionality")
+                        return True
+                    except Exception as e2:
+                        logger.error(f"Failed to initialize YouTube Music: {e2}")
+                        return False
+            
+            return False
+            
+        except Exception as e:
+            logger.error(f"Failed to authenticate with YouTube Music: {e}")
+            return False
+    
+    async def _oauth_flow(self) -> None:
+        """Perform OAuth 2.0 flow for YouTube Music."""
+        flow = Flow.from_client_config(
+            {
+                "web": {
+                    "client_id": self.config['YOUTUBE_CLIENT_ID'],
+                    "client_secret": self.config['YOUTUBE_CLIENT_SECRET'],
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "redirect_uris": [self.config['YOUTUBE_REDIRECT_URI']]
+                }
+            },
+            scopes=[
+                'https://www.googleapis.com/auth/youtube',
+                'https://www.googleapis.com/auth/youtube.readonly',
+                'https://www.googleapis.com/auth/youtubepartner'
+            ]
+        )
+        flow.redirect_uri = self.config['YOUTUBE_REDIRECT_URI']
+        
+        # Generate authorization URL
+        auth_url, _ = flow.authorization_url(prompt='consent')
+        
+        print(f"\n🔐 YouTube Music Authentication Required!")
+        print(f"🌐 Please visit this URL to authorize the application:")
+        print(f"🔗 {auth_url}")
+        print(f"\n📋 After authorization, copy the full redirect URL from your browser")
+        print(f"    (it should start with {self.config['YOUTUBE_REDIRECT_URI']})")
+        
+        # Get authorization code from user
+        redirect_response = input("\n✏️  Paste the full redirect URL here: ").strip()
+        
+        # Complete the flow
+        flow.fetch_token(authorization_response=redirect_response)
+        self.credentials = flow.credentials
+        
+        # Save credentials
+        self._save_credentials()
+    
+    async def _setup_browser_auth(self) -> bool:
+        """Setup YTMusic with browser-based authentication."""
+        try:
+            print(f"\n🎵 YouTube Music Browser Authentication")
+            print(f"📱 We need to set up browser-based authentication for YouTube Music")
+            print(f"🔗 Please go to: https://music.youtube.com/")
+            print(f"🍪 Open browser developer tools (F12) and go to Network tab")
+            print(f"📝 Look for any request and copy the 'Cookie' header")
+            
+            # For now, we'll try without authentication to test basic functionality
+            self.ytmusic = YTMusic()
+            self.authenticated = True
+            logger.info("YouTube Music initialized without authentication (limited functionality)")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to setup YouTube Music: {e}")
+            return False
+    
+    def _save_credentials(self) -> None:
+        """Save OAuth credentials to file."""
+        if self.credentials:
+            with open(self.token_file, 'w') as f:
+                json.dump({
+                    'token': self.credentials.token,
+                    'refresh_token': self.credentials.refresh_token,
+                    'token_uri': self.credentials.token_uri,
+                    'client_id': self.credentials.client_id,
+                    'client_secret': self.credentials.client_secret,
+                    'scopes': self.credentials.scopes
+                }, f)
+    
+    async def get_current_user(self) -> Dict[str, Any]:
+        """Get current authenticated user information."""
+        if not self.authenticated:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        # YouTube Music API doesn't have a direct user info endpoint
+        # Return basic info
+        return {
+            'id': 'youtube_user',
+            'name': 'YouTube Music User',
+            'followers': 0,
+            'country': 'Unknown',
+            'external_url': 'https://music.youtube.com'
+        }
+    
+    async def get_playlist_tracks(self, playlist_id: str) -> List[TrackInfo]:
+        """Get all tracks from a YouTube Music playlist."""
+        if not self.authenticated or not self.ytmusic:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        tracks = []
+        try:
+            # Get playlist details
+            playlist = self.ytmusic.get_playlist(playlist_id, limit=None)
+            
+            for track in playlist.get('tracks', []):
+                if track and track.get('videoId'):
+                    # Extract artist names
+                    artists = []
+                    if track.get('artists'):
+                        artists = [artist['name'] for artist in track['artists'] if artist.get('name')]
+                    
+                    # Extract album name
+                    album = 'Unknown'
+                    if track.get('album') and track['album'].get('name'):
+                        album = track['album']['name']
+                    
+                    track_info = TrackInfo(
+                        id=track['videoId'],
+                        name=track.get('title', 'Unknown'),
+                        artist=', '.join(artists) if artists else 'Unknown Artist',
+                        album=album,
+                        uri=f"https://music.youtube.com/watch?v={track['videoId']}",
+                        external_url=f"https://music.youtube.com/watch?v={track['videoId']}",
+                        duration_ms=self._parse_duration(track.get('duration', '0:00')) * 1000,
+                        explicit=False,  # YouTube Music doesn't expose explicit flag easily
+                        popularity=None  # Not available in YouTube Music API
+                    )
+                    tracks.append(track_info)
+            
+            logger.info(f"Retrieved {len(tracks)} tracks from YouTube Music playlist {playlist_id}")
+            return tracks
+            
+        except Exception as e:
+            logger.error(f"Failed to get playlist tracks: {e}")
+            raise Exception(f"Could not retrieve playlist {playlist_id}: {str(e)}")
+    
+    def _parse_duration(self, duration_str: str) -> int:
+        """Parse YouTube duration string to seconds."""
+        try:
+            if ':' not in duration_str:
+                return 0
+            
+            parts = duration_str.split(':')
+            if len(parts) == 2:  # MM:SS
+                return int(parts[0]) * 60 + int(parts[1])
+            elif len(parts) == 3:  # HH:MM:SS
+                return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+            else:
+                return 0
+        except:
+            return 0
+    
+    async def create_playlist(self, name: str, description: str = "", public: bool = True) -> PlaylistInfo:
+        """Create a new YouTube Music playlist."""
+        if not self.authenticated or not self.youtube_api:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            # Create playlist using YouTube Data API v3
+            request = self.youtube_api.playlists().insert(
+                part="snippet,status",
+                body={
+                    "snippet": {
+                        "title": name,
+                        "description": description
+                    },
+                    "status": {
+                        "privacyStatus": "public" if public else "private"
+                    }
+                }
+            )
+            response = request.execute()
+            playlist_id = response['id']
+            
+            playlist_info = PlaylistInfo(
+                id=playlist_id,
+                name=name,
+                description=description,
+                track_count=0,
+                external_url=f"https://music.youtube.com/playlist?list={playlist_id}",
+                public=public
+            )
+            
+            logger.info(f"Created YouTube Music playlist: {name} ({playlist_id})")
+            return playlist_info
+            
+        except Exception as e:
+            logger.error(f"Failed to create playlist: {e}")
+            raise Exception(f"Could not create playlist '{name}': {str(e)}")
+    
+    async def update_playlist_tracks(self, playlist_id: str, track_uris: List[str]) -> tuple[bool, int]:
+        """Update YouTube Music playlist with new tracks."""
+        if not self.authenticated or not self.youtube_api:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            # Extract video IDs from URIs
+            video_ids = []
+            for uri in track_uris:
+                if 'watch?v=' in uri:
+                    video_id = uri.split('watch?v=')[1].split('&')[0]
+                    video_ids.append(video_id)
+                elif uri.startswith('http'):
+                    # Skip URIs we can't parse
+                    continue
+                else:
+                    # Assume it's already a video ID
+                    video_ids.append(uri)
+            
+            if not video_ids:
+                logger.warning("No valid video IDs found in track URIs")
+                return False
+            
+            # First, clear existing playlist items (skip if new playlist)
+            try:
+                # Get current playlist items
+                request = self.youtube_api.playlistItems().list(
+                    part="id",
+                    playlistId=playlist_id,
+                    maxResults=50
+                )
+                response = request.execute()
+                
+                # Delete existing items
+                for item in response.get('items', []):
+                    self.youtube_api.playlistItems().delete(id=item['id']).execute()
+                    
+            except googleapiclient.errors.HttpError as e:
+                if e.resp.status == 404:
+                    logger.info("New playlist - skipping clear step")
+                else:
+                    logger.warning(f"Could not clear playlist: {e}")
+            except Exception as e:
+                logger.warning(f"Could not clear playlist: {e}")
+            
+            # Add new tracks using YouTube Data API v3
+            successful_adds = 0
+            for video_id in video_ids:
+                try:
+                    request = self.youtube_api.playlistItems().insert(
+                        part="snippet",
+                        body={
+                            "snippet": {
+                                "playlistId": playlist_id,
+                                "resourceId": {
+                                    "kind": "youtube#video",
+                                    "videoId": video_id
+                                }
+                            }
+                        }
+                    )
+                    request.execute()
+                    successful_adds += 1
+                except googleapiclient.errors.HttpError as e:
+                    if e.resp.status == 409:
+                        logger.debug(f"Skipping unavailable video {video_id} (region restricted or private)")
+                    elif e.resp.status == 404:
+                        logger.debug(f"Skipping non-existent video {video_id} (not found)")
+                    else:
+                        logger.warning(f"Failed to add video {video_id}: {e}")
+                    continue
+                except Exception as e:
+                    logger.warning(f"Failed to add video {video_id}: {e}")
+                    continue
+            
+            logger.info(f"Updated YouTube Music playlist {playlist_id} with {successful_adds}/{len(video_ids)} tracks")
+            # Return tuple: (success_boolean, successful_count)
+            return (successful_adds > 0, successful_adds)
+            
+        except Exception as e:
+            logger.error(f"Failed to update playlist {playlist_id}: {e}")
+            return (False, 0)
+    
+    async def find_playlist_by_name(self, name: str) -> Optional[PlaylistInfo]:
+        """Find a YouTube Music playlist by name."""
+        if not self.authenticated or not self.youtube_api:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            # Get user's playlists using YouTube Data API v3
+            request = self.youtube_api.playlists().list(
+                part="snippet,status,contentDetails",
+                mine=True,
+                maxResults=50
+            )
+            response = request.execute()
+            
+            for playlist in response.get('items', []):
+                if playlist['snippet']['title'] == name:
+                    return PlaylistInfo(
+                        id=playlist['id'],
+                        name=playlist['snippet']['title'],
+                        description=playlist['snippet'].get('description', ''),
+                        track_count=playlist['contentDetails'].get('itemCount', 0),
+                        external_url=f"https://music.youtube.com/playlist?list={playlist['id']}",
+                        public=playlist['status']['privacyStatus'] == 'public'
+                    )
+            
+            return None
+            
+        except Exception as e:
+            logger.error(f"Failed to search playlists: {e}")
+            return None
+    
+    async def search_tracks(self, query: str, limit: int = 20) -> List[TrackInfo]:
+        """Search for tracks on YouTube Music."""
+        if not self.authenticated or not self.ytmusic:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            # Search for songs
+            results = self.ytmusic.search(query, filter='songs', limit=limit)
+            tracks = []
+            
+            for result in results:
+                if result.get('videoId'):
+                    # Extract artist names
+                    artists = []
+                    if result.get('artists'):
+                        artists = [artist['name'] for artist in result['artists'] if artist.get('name')]
+                    
+                    # Extract album name
+                    album = 'Unknown'
+                    if result.get('album') and result['album'].get('name'):
+                        album = result['album']['name']
+                    
+                    track_info = TrackInfo(
+                        id=result['videoId'],
+                        name=result.get('title', 'Unknown'),
+                        artist=', '.join(artists) if artists else 'Unknown Artist',
+                        album=album,
+                        uri=f"https://music.youtube.com/watch?v={result['videoId']}",
+                        external_url=f"https://music.youtube.com/watch?v={result['videoId']}",
+                        duration_ms=self._parse_duration(result.get('duration', '0:00')) * 1000,
+                        explicit=False,  # Not easily available
+                        popularity=None  # Not available
+                    )
+                    tracks.append(track_info)
+            
+            return tracks
+            
+        except Exception as e:
+            logger.error(f"Search failed: {e}")
+            return []
+    
+    async def get_artist_info(self, artist_id: str) -> ArtistInfo:
+        """Get detailed YouTube Music artist information."""
+        if not self.authenticated or not self.ytmusic:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            artist = self.ytmusic.get_artist(artist_id)
+            
+            return ArtistInfo(
+                id=artist_id,
+                name=artist.get('name', 'Unknown Artist'),
+                genres=[],  # YouTube Music doesn't provide genre info easily
+                popularity=None,  # Not available
+                external_url=f"https://music.youtube.com/channel/{artist_id}"
+            )
+            
+        except Exception as e:
+            logger.error(f"Failed to get artist info: {e}")
+            # Return basic info
+            return ArtistInfo(
+                id=artist_id,
+                name='Unknown Artist',
+                genres=[],
+                popularity=None,
+                external_url=f"https://music.youtube.com/channel/{artist_id}"
+            )
+    
+    async def get_related_artists(self, artist_id: str) -> List[ArtistInfo]:
+        """Get artists related to the given YouTube Music artist."""
+        # YouTube Music API doesn't have a direct related artists endpoint
+        # Return empty list for now
+        return []
+    
+    async def get_artist_top_tracks(self, artist_id: str, limit: int = 10) -> List[TrackInfo]:
+        """Get top tracks for a YouTube Music artist."""
+        if not self.authenticated or not self.ytmusic:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            artist = self.ytmusic.get_artist(artist_id)
+            songs = artist.get('songs', {}).get('results', [])
+            
+            tracks = []
+            for song in songs[:limit]:
+                if song.get('videoId'):
+                    track_info = TrackInfo(
+                        id=song['videoId'],
+                        name=song.get('title', 'Unknown'),
+                        artist=artist.get('name', 'Unknown Artist'),
+                        album=song.get('album', {}).get('name', 'Unknown') if song.get('album') else 'Unknown',
+                        uri=f"https://music.youtube.com/watch?v={song['videoId']}",
+                        external_url=f"https://music.youtube.com/watch?v={song['videoId']}",
+                        duration_ms=self._parse_duration(song.get('duration', '0:00')) * 1000,
+                        explicit=False,
+                        popularity=None
+                    )
+                    tracks.append(track_info)
+            
+            return tracks
+            
+        except Exception as e:
+            logger.error(f"Failed to get artist top tracks: {e}")
+            return []
+    
+    async def get_user_saved_tracks(self, limit: int = 50) -> List[TrackInfo]:
+        """Get user's liked tracks from YouTube Music."""
+        if not self.authenticated or not self.ytmusic:
+            raise Exception("Not authenticated with YouTube Music")
+        
+        try:
+            # Get liked songs playlist
+            liked_songs = self.ytmusic.get_liked_songs(limit=limit)
+            tracks = []
+            
+            for track in liked_songs.get('tracks', []):
+                if track.get('videoId'):
+                    artists = []
+                    if track.get('artists'):
+                        artists = [artist['name'] for artist in track['artists'] if artist.get('name')]
+                    
+                    track_info = TrackInfo(
+                        id=track['videoId'],
+                        name=track.get('title', 'Unknown'),
+                        artist=', '.join(artists) if artists else 'Unknown Artist',
+                        album=track.get('album', {}).get('name', 'Unknown') if track.get('album') else 'Unknown',
+                        uri=f"https://music.youtube.com/watch?v={track['videoId']}",
+                        external_url=f"https://music.youtube.com/watch?v={track['videoId']}",
+                        duration_ms=self._parse_duration(track.get('duration', '0:00')) * 1000,
+                        explicit=False,
+                        popularity=None
+                    )
+                    tracks.append(track_info)
+            
+            return tracks
+            
+        except Exception as e:
+            logger.error(f"Failed to get user saved tracks: {e}")
+            return [] 

--- a/spotify_usage_history_backup.json
+++ b/spotify_usage_history_backup.json
@@ -1,0 +1,506 @@
+{
+  "28IEbk5a7twNTbUEvWslUb": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Paralyzer",
+    "artist": "Finger Eleven",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "25GC50HslaaruyrKjdu0lP": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Your Betrayal",
+    "artist": "Bullet For My Valentine",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "3cahdRG7Ht3KyCAJKCk4Qk": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Don't Pray for an Easy Life",
+    "artist": "Fearless Motivation, Alpha",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "4e9eGQYsOiBcftrWXwsVco": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Aerials",
+    "artist": "System Of A Down",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "1gyee1JuFFiP476LQpRMYU": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "The Red",
+    "artist": "Chevelle",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "44NRdYQw7P0GWuiunRv3hr": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "I Stand Alone",
+    "artist": "Godsmack",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "0INUE1K7cEiE8VH63Rv5RJ": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Happy?",
+    "artist": "Mudvayne",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "059MUIi9GmBbrFs4fYKtiu": {
+    "count": 5,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Action",
+    "artist": "Mandrazo, MOHA, Duava",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "3Ol8ZL9iaL4IfaSi7eTLTe": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Eon - Au5 Remix",
+    "artist": "Celldweller, Au5",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "3e2KBwxibC1rq4bA5TNKW2": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Psycho",
+    "artist": "Puddle Of Mudd",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "6ZxrUCaynLgKSUudACOTwj": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Cold",
+    "artist": "Crossfade",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "2YqnxVHd6o2AXwnT33frov": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Power",
+    "artist": "braev, N3WPORT",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "0jqK7sGTLsHPkQrrcrGuKD": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Still Waiting",
+    "artist": "Sum 41",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "7hVh8pHZcZsh0m9JSezebB": {
+    "count": 5,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "No, This Is Patrick",
+    "artist": "Like a Villain, Claas, Adam Ramey",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "18vrKPS0oVhYVNHRkONp3A": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Nine Thou - Grant Mohrman Superstars Remix",
+    "artist": "Styles Of Beyond, Grant Mohrman",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "6XimI1O15wpfwUdrCnlrxo": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "All These Things I Hate (Revolve Around Me)",
+    "artist": "Bullet For My Valentine",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "5sxyNRAlsVwxOOQrXgs5kF": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "The Only Thing They Fear is You (From \"Doom: Eternal\")",
+    "artist": "FamilyJules",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "0L7lTy1aRn1TYYCTazcO5j": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Run for Your Life",
+    "artist": "The Seige",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "6njppEOeoUxbEx1BAXsF8p": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Erase My Scars",
+    "artist": "Evans Blue",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "5f92OpAQ0TenbweMyWR3Fb": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Rise",
+    "artist": "State of Mine",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "4EchqUKQ3qAQuRNKmeIpnf": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "The Kids Aren't Alright",
+    "artist": "The Offspring",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "2gwm8nC9BGwPe2zroeBsdv": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Other Position - Remix",
+    "artist": "Dark Boy",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "1BqzzWlA868p8J5VIbp50A": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Better Days",
+    "artist": "Currents",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "3ENHpbTuY72FukZbwGP6bc": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Tear Away",
+    "artist": "Drowning Pool",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "1x0AirtLjfVquI0A9iBVep": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Getting Away With Murder",
+    "artist": "Papa Roach",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "0lP4HYLmvowOKdsQ7CVkuq": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "The Kill",
+    "artist": "Thirty Seconds To Mars",
+    "last_used": "2025-08-07T01:37:34.680791"
+  },
+  "00EnN4XfNdQYzOh6oimHfc": {
+    "count": 5,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Pressure",
+    "artist": "Skan, LBLVNC, Drama B",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "76xddM2irVQCbuBoVbaElZ": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Downfall",
+    "artist": "TRUSTcompany",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "7iwiTEn7PJYhB4vf3szzAN": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "We Own It (Fast & Furious)",
+    "artist": "2 Chainz, Wiz Khalifa",
+    "last_used": "2025-08-07T01:37:34.680791"
+  },
+  "18Uay1003reV0z2KaK97NY": {
+    "count": 8,
+    "first_used": "2025-08-07T01:27:24.265610",
+    "track_name": "Sturmmaske auf - Gold war Gestern RMX",
+    "artist": "Kollegah, Farid Bang, 18 Karat, JIGZAW, Summer Cem, King Khalil",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "18Ci4p96mIISRxyGAyONYw": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Kill the Power",
+    "artist": "Skindred",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "2uO6LTp2vi4VlgEH9Gaj3R": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "My Soldiers Rage",
+    "artist": "Maul",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "2D9BrlpeyjXF0vli2dYQ5V": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Angels Fall",
+    "artist": "Breaking Benjamin",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "60OKW0mZiPFHVpHl3eHueg": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Fix Me",
+    "artist": "10 Years",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "48ncRBVLgiu8MY7O70VVw5": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Ladies And Gentlemen",
+    "artist": "Saliva",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "3UygY7qW2cvG9Llkay6i1i": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Going Under",
+    "artist": "Evanescence",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "5nyef8bHyXaglyArVUNlre": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Deadwood",
+    "artist": "Really Slow Motion",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "3zFG5dyH5rJfkZ25fgR173": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Sound Of A Gun",
+    "artist": "Audioslave",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "2HerxRQish8VLHvu20oxz2": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Always",
+    "artist": "Saliva",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "5F9PXDOkRo697199KrkU0e": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Free Me",
+    "artist": "NEFFEX",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "5pKCDm2fw4k6D6C5Rk646C": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Tears Don't Fall",
+    "artist": "Bullet For My Valentine",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "6uiVoZ65Gf98Wyeuf0NRZr": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Losing Control",
+    "artist": "Red",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "0M955bMOoilikPXwKLYpoi": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "I Hate Everything About You",
+    "artist": "Three Days Grace",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "6p2liQLGoDaLXgND68bfVt": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Coming Undone",
+    "artist": "Korn",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "6OSNG3ajax69sNsmTEaPyJ": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Dreamers & Believers",
+    "artist": "The Fire & Fury",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "6sREV6MpLHTqcOmBK5mvYF": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Face to the Floor",
+    "artist": "Chevelle",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "5Cl9GDb0AyQnppRr6q7ldb": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Broken",
+    "artist": "From Ashes to New",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "6Q1m1GyNxyOwZ2ud3p7XoS": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Gasoline",
+    "artist": "I Prevail",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "2gSVKxPDww9Eep5rdvtdem": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "My Way",
+    "artist": "Limp Bizkit",
+    "last_used": "2025-08-07T01:39:39.730400"
+  },
+  "48vkclgG3Fmbvrln1RqtDh": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Reassemble",
+    "artist": "A Day To Remember",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "3tEzvgGyJAtg1EJAUCRlsM": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Scratch & Claw",
+    "artist": "Dropout Kings",
+    "last_used": "2025-08-07T01:39:31.052555"
+  },
+  "6dRAAG4sB71NAtVCHJep7s": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Send the Pain Below",
+    "artist": "Chevelle",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "4U0p10TUdRyhQ06ZqGAtxx": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Undead",
+    "artist": "Hollywood Undead",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "4oKcFaWmBSF3SGGYo4qq6R": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:33.970594",
+    "track_name": "Teesri Manzil",
+    "artist": "DIVINE",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "0CA3RxBx2xSQXPfpmUBK1v": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Just Like You",
+    "artist": "Three Days Grace",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "2S2KuxanBtLEfR9ckyCAjC": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Idgaf",
+    "artist": "Zero Pandas, Really Slow Motion",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "4zzttZti7oNKG9438Jmcm6": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Blood bath",
+    "artist": "Adhya",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "3NNPXSLp2aHYY8sD4q9Mhe": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Blow Up",
+    "artist": "Ivan B",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "7cqxlbIjtgXOj3on2jHxp7": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "City of the Sun",
+    "artist": "The Veer Union",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "1XZrMIHtCVJPqK29Mzm44G": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Bottom of a Bottle",
+    "artist": "Smile Empty Soul",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "0nTiC2fGkM4q8bGlBKGrGx": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Wasteland",
+    "artist": "10 Years",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "4ruvnIlUX6mOyum1himQQW": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Lost Within",
+    "artist": "Fivefold",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "0snQkGI5qnAmohLE7jTsTn": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Toxicity",
+    "artist": "System Of A Down",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "1XamHHIxkTov0g4Sii0gQV": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Rebirth",
+    "artist": "Noija",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "6hPogogJd3U6CIkqFSfb02": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Chance",
+    "artist": "Silent Season",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "2nUy0ifVE7UwtOK4rugFsP": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "The End of Heartache",
+    "artist": "Killswitch Engage",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "1LMVGL3030W3mGmRrd2hCm": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Click Click Boom",
+    "artist": "Saliva",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "4JjUwfp8GQ3PxWg2QPKnpn": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "300 Violin Orchestra",
+    "artist": "Jorge Quintero",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "3iWNrDvyW8jxiOL0ZJgcJM": {
+    "count": 4,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Numb",
+    "artist": "The Monster Inside",
+    "last_used": "2025-08-07T16:21:13.334884"
+  },
+  "100qCC3DZSSnrhYCkd1ORe": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Wrath of the Champions",
+    "artist": "Jorge Quintero",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "0vyEd7P4p2eNNvd5YONJry": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Fuck With My Head",
+    "artist": "Saint Chaos",
+    "last_used": "2025-08-07T16:21:04.270911"
+  },
+  "3a9urnht8HvfFzPwd0ipx6": {
+    "count": 3,
+    "first_used": "2025-08-07T01:27:36.690986",
+    "track_name": "Holy Diver",
+    "artist": "Killswitch Engage",
+    "last_used": "2025-08-07T16:21:04.270911"
+  }
+}


### PR DESCRIPTION
Expanded the music playlist generator to support multi-service integrations with YouTube Music and Amazon Music.

- Updated `.gitignore` to include environment and credential files for new music services.
- Added complete implementation for YouTube Music service, including OAuth authentication, playlist management, track search, and user history management.
- Developed a comprehensive integration guide in `INTEGRATION_GUIDE.md`, detailing steps for setting up and implementing YouTube Music and Amazon Music.
- Updated `README.md` to reflect new features, supported services, and enhanced functionalities.
- Introduced `base_music_service.py` for standardized service interfaces, enabling easy expansion and consistent implementations across different platforms.
- Implemented `main.py` as the primary CLI for managing and utilizing all available music services interactively.
- Updated `requirements.txt` to include necessary packages for YouTube Music and commented placeholders for future Amazon Music dependencies.
- Created `service_manager.py` for centralized service configuration management, ensuring seamless registration and initialization of various music services.

These changes enable users to discover and curate playlists not only on Spotify but also on YouTube Music and potentially Amazon Music, enhancing the versatility and reach of the application.